### PR TITLE
Updated Marinho e Pinto

### DIFF
--- a/meps_full_list_with_twitter_accounts.csv
+++ b/meps_full_list_with_twitter_accounts.csv
@@ -414,7 +414,7 @@ MANSCOUR Louis-Joseph,http://www.twitter.com/LJManscour,@LJManscour,France,Group
 MARCELLESI Florent,https://twitter.com/fmarcellesi,@fmarcellesi,Spain,Group of the Greens/European Free Alliance
 MARIAS Notis,http://www.twitter.com/Notis_Marias,@Notis_Marias,Greece,European Conservatives and Reformists Group
 MARINESCU Marian-Jean,http://www.twitter.com/MarianMarinescu,@MarianMarinescu,Romania,Group of the European People's Party (Christian Democrats)
-MARINHO E PINTO António,http://www.twitter.com/marinhoepinto,@marinhoepinto,Portugal,Group of the Alliance of Liberals and Democrats for Europe
+MARINHO E PINTO António,http://www.twitter.com/marinhoepintoeu,@marinhoepintoeu,Portugal,Group of the Alliance of Liberals and Democrats for Europe
 MARTIN David,http://www.twitter.com/davidmartinmep,@davidmartinmep,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 MARTIN Dominique,http://www.twitter.com/DMartinFN,@DMartinFN,France,Europe of Nations and Freedom Group
 MARTIN Edouard,http://www.twitter.com/edouardmartinEU,@edouardmartinEU,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament


### PR DESCRIPTION
The Twitter account of Marinho e Pinto, as MEP is @marinhopintoeu. The @marinhoepinto account is his lawyer/personal account.