### PR TITLE
Update to current MEPs and multiple adjustments

### DIFF
--- a/meps_full_list_with_twitter_accounts.csv
+++ b/meps_full_list_with_twitter_accounts.csv
@@ -1,12 +1,12 @@
 NAME,TWITTER_URL,SCREEN_NAME,NATIONALITY,GROUP
-Abir AL-SAHLANI,https://twitter.com/abiralsahlani,@abiralsahlani,Sweden,Renew Europe Group
+Abir AL-SAHLANI,https://twitter.com/AbirAlsahlani,@AbirAlsahlani,Sweden,Renew Europe Group
 Adam BIELAN,https://twitter.com/AdamBielan,@AdamBielan,Poland,European Conservatives and Reformists Group
 Adam JARUBAS,https://twitter.com/JarubasAdam,@JarubasAdam,Poland,Group of the European People's Party (Christian Democrats)
 Ádám KÓSA,https://twitter.com/adamkosamep,@adamkosamep,Hungary,Group of the European People's Party (Christian Democrats)
 Adina-Ioana VĂLEAN,https://twitter.com/AdinaValean,@AdinaValean,Romania,Group of the European People's Party (Christian Democrats)
 Adrian-Dragoş BENEA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Adriana MALDONADO LÓPEZ,https://twitter.com/_AMaldonado_,@_AMaldonado_,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Agnès EVREN,https://twitter.com/agnesevren,@agnesevren,France,Group of the European People's Party (Christian Democrats)
+Agnès EVREN,https://twitter.com/AgnesEvren,@AgnesEvren,France,Group of the European People's Party (Christian Democrats)
 Agnes JONGERIUS,https://twitter.com/a_jongerius,@a_jongerius,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Aileen McLEOD,https://twitter.com/AileenMcLeodSNP,@AileenMcLeodSNP,United Kingdom,Group of the Greens/European Free Alliance
 Aldo PATRICIELLO,https://twitter.com/PatricielloAldo,@PatricielloAldo,Italy,Group of the European People's Party (Christian Democrats)
@@ -16,9 +16,9 @@ Alessandro PANZA,https://twitter.com/alepanzaoff,@alepanzaoff,Italy,Identity and
 Alex AGIUS SALIBA,https://twitter.com/alexagiussaliba,@alexagiussaliba,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Alexander ALEXANDROV YORDANOV,,,Bulgaria,Group of the European People's Party (Christian Democrats)
 Alexander BERNHUBER,,,Austria,Group of the European People's Party (Christian Democrats)
-Alexandr VONDRA,https://twitter.com/alexandrvondra,@alexandrvondra,Czechia,European Conservatives and Reformists Group
+Alexandr VONDRA,https://twitter.com/AlexandrVondra,@AlexandrVondra,Czechia,European Conservatives and Reformists Group
 Alexandra GEESE,https://twitter.com/alexandra_geese,@alexandra_geese,Germany,Group of the Greens/European Free Alliance
-Alexandra Lesley PHILLIPS,https://twitter.com/brexitalex,@brexitalex,United Kingdom,Non-attached Members
+Alexandra Lesley PHILLIPS,https://twitter.com/BrexitAlex,@BrexitAlex,United Kingdom,Non-attached Members
 Alexandra Louise Rosenfield PHILLIPS,https://twitter.com/alexforeurope,@alexforeurope,United Kingdom,Group of the Greens/European Free Alliance
 Alexis GEORGOULIS,https://twitter.com/AlexisMep,@AlexisMep,Greece,Confederal Group of the European United Left - Nordic Green Left
 Alfred SANT,https://twitter.com/SantAlfred,@SantAlfred,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -26,18 +26,18 @@ Alice KUHNKE,,,Sweden,Group of the Greens/European Free Alliance
 Alicia HOMS GINEL,https://twitter.com/aliciahoms,@aliciahoms,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Álvaro AMARO,,,Portugal,Group of the European People's Party (Christian Democrats)
 Alyn SMITH,https://twitter.com/AlynSmith,@AlynSmith,United Kingdom,Group of the Greens/European Free Alliance
-Andor DELI,https://twitter.com/andordeli,@andordeli,Hungary,Group of the European People's Party (Christian Democrats)
+Andor DELI,https://twitter.com/AndorDeli,@AndorDeli,Hungary,Group of the European People's Party (Christian Democrats)
 András GYÜRK,,,Hungary,Group of the European People's Party (Christian Democrats)
 André ROUGÉ,https://twitter.com/AndreRougeOff,@AndreRougeOff,France,Identity and Democracy Group
 Andrea BOCSKOR,https://twitter.com/AndreaBocskor,@AndreaBocskor,Hungary,Group of the European People's Party (Christian Democrats)
 Andrea CAROPPO,https://twitter.com/caroppo_andrea,@caroppo_andrea,Italy,Identity and Democracy Group
 Andrea COZZOLINO,https://twitter.com/cozzolino62,@cozzolino62,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Andreas GLÜCK,https://twitter.com/Andi_Glueck,@Andi_Glueck,Germany,Renew Europe Group
-Andreas SCHIEDER,https://twitter.com/schieder,@schieder,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Andreas SCHIEDER,https://twitter.com/SCHIEDER,@SCHIEDER,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Andreas SCHWAB,https://twitter.com/Andreas_Schwab,@Andreas_Schwab,Germany,Group of the European People's Party (Christian Democrats)
 Andrew ENGLAND KERR,https://twitter.com/englandkerrmep,@englandkerrmep,United Kingdom,Non-attached Members
 Andrey KOVATCHEV,https://twitter.com/andreykovatchev,@andreykovatchev,Bulgaria,Group of the European People's Party (Christian Democrats)
-Andrey NOVAKOV,https://twitter.com/andreynovakov,@andreynovakov,Bulgaria,Group of the European People's Party (Christian Democrats)
+Andrey NOVAKOV,https://twitter.com/AndreyNovakov,@AndreyNovakov,Bulgaria,Group of the European People's Party (Christian Democrats)
 Andrey SLABAKOV,,,Bulgaria,European Conservatives and Reformists Group
 Andris AMERIKS,https://twitter.com/AndrisAmeriks,@AndrisAmeriks,Latvia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Andrius KUBILIUS,https://twitter.com/AndriusKubilius,@AndriusKubilius,Lithuania,Group of the European People's Party (Christian Democrats)
@@ -46,7 +46,7 @@ Andrzej HALICKI,https://twitter.com/AndrzejHalicki,@AndrzejHalicki,Poland,Group 
 Andżelika Anna MOŻDŻANOWSKA,,,Poland,European Conservatives and Reformists Group
 Angel DZHAMBAZKI,https://twitter.com/djambazki,@djambazki,Bulgaria,European Conservatives and Reformists Group
 Angelika NIEBLER,https://twitter.com/ANiebler,@ANiebler,Germany,Group of the European People's Party (Christian Democrats)
-Angelika WINZIG,https://twitter.com/angelikawinzig,@angelikawinzig,Austria,Group of the European People's Party (Christian Democrats)
+Angelika WINZIG,https://twitter.com/AngelikaWinzig,@AngelikaWinzig,Austria,Group of the European People's Party (Christian Democrats)
 Angelo CIOCCA,https://twitter.com/AngeloCiocca,@AngeloCiocca,Italy,Identity and Democracy Group
 Anja HAZEKAMP,https://twitter.com/anjahazekamp,@anjahazekamp,Netherlands,Confederal Group of the European United Left - Nordic Green Left
 Ann WIDDECOMBE,,,United Kingdom,Non-attached Members
@@ -57,7 +57,7 @@ Anna FOTYGA,https://twitter.com/AnnaFotyga_PE,@AnnaFotyga_PE,Poland,European Con
 Anna Júlia DONÁTH,https://twitter.com/donath_anna,@donath_anna,Hungary,Renew Europe Group
 Anna ZALEWSKA,https://twitter.com/_AnnaZalewska,@_AnnaZalewska,Poland,European Conservatives and Reformists Group
 Anna-Michelle ASIMAKOPOULOU,https://twitter.com/AnnaAsimakopoul,@AnnaAsimakopoul,Greece,Group of the European People's Party (Christian Democrats)
-Annalisa TARDINO,https://twitter.com/tardinoannalisa,@tardinoannalisa,Italy,Identity and Democracy Group
+Annalisa TARDINO,https://twitter.com/TardinoAnnalisa,@TardinoAnnalisa,Italy,Identity and Democracy Group
 Anne SANDER,https://twitter.com/ASanderMEP,@ASanderMEP,France,Group of the European People's Party (Christian Democrats)
 Anne-Sophie PELLETIER,https://twitter.com/ASPelletier,@ASPelletier,France,Confederal Group of the European United Left - Nordic Green Left
 Annie SCHREIJER-PIERIK,https://twitter.com/AnnieSchreijer,@AnnieSchreijer,Netherlands,Group of the European People's Party (Christian Democrats)
@@ -69,11 +69,11 @@ Antonio Maria RINALDI,https://twitter.com/Rinaldi_euro,@Rinaldi_euro,Italy,Ident
 Antonio TAJANI,https://twitter.com/Antonio_Tajani,@Antonio_Tajani,Italy,Group of the European People's Party (Christian Democrats)
 Antonius MANDERS,,,Netherlands,Group of the European People's Party (Christian Democrats)
 Antony HOOK,https://twitter.com/AntonyHookMEP,@AntonyHookMEP,United Kingdom,Renew Europe Group
-Arba KOKALARI,https://twitter.com/arbakokalari,@arbakokalari,Sweden,Group of the European People's Party (Christian Democrats)
+Arba KOKALARI,https://twitter.com/ArbaKokalari,@ArbaKokalari,Sweden,Group of the European People's Party (Christian Democrats)
 Arnaud DANJEAN,https://twitter.com/ArnaudDanjean,@ArnaudDanjean,France,Group of the European People's Party (Christian Democrats)
 Asger CHRISTENSEN,https://twitter.com/AsgerChristens2,@AsgerChristens2,Denmark,Renew Europe Group
 Asim ADEMOV,https://twitter.com/AdemovAsim,@AdemovAsim,Bulgaria,Group of the European People's Party (Christian Democrats)
-Assita KANKO,https://twitter.com/assita_kanko,@assita_kanko,Belgium,European Conservatives and Reformists Group
+Assita KANKO,https://twitter.com/Assita_Kanko,@Assita_Kanko,Belgium,European Conservatives and Reformists Group
 Athanasios KONSTANTINOU,,,Greece,Non-attached Members
 Atidzhe ALIEVA-VELI,,,Bulgaria,Renew Europe Group
 Attila ARA-KOVÁCS,https://twitter.com/AraKovacs,@AraKovacs,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -86,7 +86,7 @@ Barbara Ann GIBSON,https://twitter.com/Barb_G,@Barb_G,United Kingdom,Renew Europ
 Barbara THALER,https://twitter.com/thalerbarbara,@thalerbarbara,Austria,Group of the European People's Party (Christian Democrats)
 Bartosz ARŁUKOWICZ,https://twitter.com/Arlukowicz,@Arlukowicz,Poland,Group of the European People's Party (Christian Democrats)
 Bas EICKHOUT,https://twitter.com/BasEickhout,@BasEickhout,Netherlands,Group of the Greens/European Free Alliance
-Beata KEMPA,https://twitter.com/beatakempa_kprm,@beatakempa_kprm,Poland,European Conservatives and Reformists Group
+Beata KEMPA,https://twitter.com/BeataKempa_KPRM,@BeataKempa_KPRM,Poland,European Conservatives and Reformists Group
 Beata MAZUREK,https://twitter.com/beatamk,@beatamk,Poland,European Conservatives and Reformists Group
 Beata SZYDŁO,https://twitter.com/BeataSzydlo,@BeataSzydlo,Poland,European Conservatives and Reformists Group
 Belinda DE LUCY,https://twitter.com/BelindadeLucy,@BelindadeLucy,United Kingdom,Non-attached Members
@@ -102,19 +102,19 @@ Biljana BORZAN,https://twitter.com/BiljanaBorzan,@BiljanaBorzan,Croatia,Group of
 Bill NEWTON DUNN,https://twitter.com/billnewtondunn,@billnewtondunn,United Kingdom,Renew Europe Group
 Billy KELLEHER,https://twitter.com/BillyKelleherEU,@BillyKelleherEU,Ireland,Renew Europe Group
 Birgit SIPPEL,https://twitter.com/BirgitSippelMEP,@BirgitSippelMEP,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Bogdan RZOŃCA,https://twitter.com/bogdan_rzonca,@bogdan_rzonca,Poland,European Conservatives and Reformists Group
+Bogdan RZOŃCA,https://twitter.com/Bogdan_Rzonca,@Bogdan_Rzonca,Poland,European Conservatives and Reformists Group
 Bogusław LIBERADZKI,https://twitter.com/BLiberadzki,@BLiberadzki,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Brando BENIFEI,https://twitter.com/brandobenifei,@brandobenifei,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Brian MONTEITH,https://twitter.com/TheBluetrot,@TheBluetrot,United Kingdom,Non-attached Members
 Brice HORTEFEUX,https://twitter.com/BriceHortefeux,@BriceHortefeux,France,Group of the European People's Party (Christian Democrats)
 Bronis ROPĖ,https://twitter.com/BronisRopeLT,@BronisRopeLT,Lithuania,Group of the Greens/European Free Alliance
 Carlo CALENDA,https://twitter.com/CarloCalenda,@CarloCalenda,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Carlo FIDANZA,https://twitter.com/fidanzacarlo,@fidanzacarlo,Italy,European Conservatives and Reformists Group
+Carlo FIDANZA,https://twitter.com/FidanzaCarlo,@FidanzaCarlo,Italy,European Conservatives and Reformists Group
 Carlos ZORRINHO,https://twitter.com/czorrinho,@czorrinho,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Carmen AVRAM,https://twitter.com/carmenavram,@carmenavram,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Caroline NAGTEGAAL,https://twitter.com/c_nagtegaal,@c_nagtegaal,Netherlands,Renew Europe Group
+Caroline NAGTEGAAL,https://twitter.com/C_Nagtegaal,@C_Nagtegaal,Netherlands,Renew Europe Group
 Caroline ROOSE,https://twitter.com/CarolineRooseEU,@CarolineRooseEU,France,Group of the Greens/European Free Alliance
-Caroline VOADEN,https://twitter.com/carolinevoaden,@carolinevoaden,United Kingdom,Renew Europe Group
+Caroline VOADEN,https://twitter.com/CarolineVoaden,@CarolineVoaden,United Kingdom,Renew Europe Group
 Caterina CHINNICI,https://twitter.com/CaterinaChinnic,@CaterinaChinnic,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Catherine BEARDER,https://twitter.com/catherinemep,@catherinemep,United Kingdom,Renew Europe Group
 Catherine CHABAUD,https://twitter.com/CathChabaud,@CathChabaud,France,Renew Europe Group
@@ -126,21 +126,21 @@ Charlie WEIMERS,https://twitter.com/weimers,@weimers,Sweden,European Conservativ
 Chiara GEMMA,https://twitter.com/chgemma68,@chgemma68,Italy,Non-attached Members
 Chris DAVIES,https://twitter.com/ChrisDaviesEU,@ChrisDaviesEU,United Kingdom,Renew Europe Group
 Christel SCHALDEMOSE,https://twitter.com/SchaldemoseMEP,@SchaldemoseMEP,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Christian ALLARD,https://twitter.com/christia_allard,@christia_allard,United Kingdom,Group of the Greens/European Free Alliance
+Christian ALLARD,https://twitter.com/Christia_Allard,@Christia_Allard,United Kingdom,Group of the Greens/European Free Alliance
 Christian EHLER,,,Germany,Group of the European People's Party (Christian Democrats)
 Christian DOLESCHAL,https://twitter.com/Doleschal,@Doleschal,Germany,Group of the European People's Party (Christian Democrats)
 Christina Sheila JORDAN,https://twitter.com/CJordanjb,@CJordanjb,United Kingdom,Non-attached Members
 Christine ANDERSON,,,Germany,Identity and Democracy Group
 Christine SCHNEIDER,https://twitter.com/ChSchneider,@ChSchneider,Germany,Group of the European People's Party (Christian Democrats)
-Christophe GRUDLER,https://twitter.com/grudlerch,@grudlerch,France,Renew Europe Group
+Christophe GRUDLER,https://twitter.com/GrudlerCh,@GrudlerCh,France,Renew Europe Group
 Christophe HANSEN,https://twitter.com/CHansenEU,@CHansenEU,Luxembourg,Group of the European People's Party (Christian Democrats)
 Chrysoula ZACHAROPOULOU,https://twitter.com/CZacharopoulou,@CZacharopoulou,France,Renew Europe Group
-Ciarán CUFFE,https://twitter.com/ciarancuffe,@ciarancuffe,Ireland,Group of the Greens/European Free Alliance
-Cindy FRANSSEN,https://twitter.com/franssencindy,@franssencindy,Belgium,Group of the European People's Party (Christian Democrats)
-Claire FOX,https://twitter.com/fox_claire,@fox_claire,United Kingdom,Non-attached Members
+Ciarán CUFFE,https://twitter.com/CiaranCuffe,@CiaranCuffe,Ireland,Group of the Greens/European Free Alliance
+Cindy FRANSSEN,https://twitter.com/FranssenCindy,@FranssenCindy,Belgium,Group of the European People's Party (Christian Democrats)
+Claire FOX,https://twitter.com/Fox_Claire,@Fox_Claire,United Kingdom,Non-attached Members
 Clara AGUILERA,https://twitter.com/ClaraAguilera7,@ClaraAguilera7,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Clare DALY,https://twitter.com/ClareDalyMEP,@ClareDalyMEP,Ireland,Confederal Group of the European United Left - Nordic Green Left
-Claude MORAES,https://twitter.com/claude_moraes,@claude_moraes,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Claude MORAES,https://twitter.com/Claude_Moraes,@Claude_Moraes,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Claudia GAMON,https://twitter.com/dieGamon,@dieGamon,Austria,Renew Europe Group
 Cláudia MONTEIRO DE AGUIAR,https://twitter.com/cmonteiroaguiar,@cmonteiroaguiar,Portugal,Group of the European People's Party (Christian Democrats)
 Claudiu MANDA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -157,19 +157,19 @@ Csaba MOLNÁR,,,Hungary,Group of the Progressive Alliance of Socialists and Demo
 Dace MELBĀRDE,,,Latvia,European Conservatives and Reformists Group
 Dacian CIOLOŞ,https://twitter.com/CiolosDacian,@CiolosDacian,Romania,Renew Europe Group
 Damian BOESELAGER,https://twitter.com/d_boeselager,@d_boeselager,Germany,Group of the Greens/European Free Alliance
-Damien CARÊME,https://twitter.com/damiencareme,@damiencareme,France,Group of the Greens/European Free Alliance
+Damien CARÊME,https://twitter.com/DamienCAREME,@DamienCAREME,France,Group of the Greens/European Free Alliance
 Dan NICA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Dan-Ştefan MOTREANU,https://twitter.com/Dan_Motreanu,@Dan_Motreanu,Romania,Group of the European People's Party (Christian Democrats)
 Daniel BUDA,https://twitter.com/MEPDanielBuda,@MEPDanielBuda,Romania,Group of the European People's Party (Christian Democrats)
 Daniel CASPARY,https://twitter.com/caspary,@caspary,Germany,Group of the European People's Party (Christian Democrats)
 Daniel FREUND,https://twitter.com/daniel_freund,@daniel_freund,Germany,Group of the Greens/European Free Alliance
-Daniel HANNAN,https://twitter.com/danieljhannan,@danieljhannan,United Kingdom,European Conservatives and Reformists Group
+Daniel HANNAN,https://twitter.com/DanielJHannan,@DanielJHannan,United Kingdom,European Conservatives and Reformists Group
 Daniela RONDINELLI,https://twitter.com/Dani_Rondinelli,@Dani_Rondinelli,Italy,Non-attached Members
 Danuta Maria HÜBNER,https://twitter.com/danutahuebner,@danutahuebner,Poland,Group of the European People's Party (Christian Democrats)
 David BULL,https://twitter.com/drdavidbull,@drdavidbull,United Kingdom,Non-attached Members
 David CASA,https://twitter.com/DavidCasaMEP,@DavidCasaMEP,Malta,Group of the European People's Party (Christian Democrats)
 David CORMAND,https://twitter.com/DavidCormand,@DavidCormand,France,Group of the Greens/European Free Alliance
-David LEGA,https://twitter.com/davidlega,@davidlega,Sweden,Group of the European People's Party (Christian Democrats)
+David LEGA,https://twitter.com/DavidLega,@DavidLega,Sweden,Group of the European People's Party (Christian Democrats)
 David McALLISTER,https://twitter.com/davidmcallister,@davidmcallister,Germany,Group of the European People's Party (Christian Democrats)
 David Maria SASSOLI,https://twitter.com/DavidSassoli,@DavidSassoli,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Delara BURKHARDT,https://twitter.com/delarabur,@delarabur,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -183,9 +183,9 @@ Dimitrios PAPADIMOULIS,https://twitter.com/papadimoulis,@papadimoulis,Greece,Con
 Dinesh DHAMIJA,https://twitter.com/dinesh_dhamija,@dinesh_dhamija,United Kingdom,Renew Europe Group
 Dino GIARRUSSO,https://twitter.com/DinoGiarrusso,@DinoGiarrusso,Italy,Non-attached Members
 Dita CHARANZOVÁ,https://twitter.com/charanzova,@charanzova,Czechia,Renew Europe Group
-Dolors MONTSERRAT,https://twitter.com/dolorsmm,@dolorsmm,Spain,Group of the European People's Party (Christian Democrats)
-Domènec RUIZ DEVESA,https://twitter.com/domenecd,@domenecd,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Dominique BILDE,https://twitter.com/dominiquebilde,@dominiquebilde,France,Identity and Democracy Group
+Dolors MONTSERRAT,https://twitter.com/DolorsMM,@DolorsMM,Spain,Group of the European People's Party (Christian Democrats)
+Domènec RUIZ DEVESA,https://twitter.com/DomenecD,@DomenecD,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Dominique BILDE,https://twitter.com/DominiqueBilde,@DominiqueBilde,France,Identity and Democracy Group
 Dominique RIQUET,https://twitter.com/DominiqueRiquet,@DominiqueRiquet,France,Renew Europe Group
 Dragoş PÎSLARU,https://twitter.com/dragos_pislaru,@dragos_pislaru,Romania,Renew Europe Group
 Dragoş TUDORACHE,https://twitter.com/IoanDragosT,@IoanDragosT,Romania,Renew Europe Group
@@ -196,22 +196,22 @@ Eider GARDIAZABAL RUBIAL,https://twitter.com/EGardiazabal,@EGardiazabal,Spain,Gr
 Elena KOUNTOURA,https://twitter.com/ElenaKountoura,@ElenaKountoura,Greece,Confederal Group of the European United Left - Nordic Green Left
 Elena LIZZI,https://twitter.com/elenalizzi,@elenalizzi,Italy,Identity and Democracy Group
 Elena YONCHEVA,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Eleonora EVI,https://twitter.com/eleonoraevi,@eleonoraevi,Italy,Non-attached Members
+Eleonora EVI,https://twitter.com/EleonoraEvi,@EleonoraEvi,Italy,Non-attached Members
 Elisabetta GUALMINI,https://twitter.com/gualminielisa,@gualminielisa,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Elissavet VOZEMBERG-VRIONIDI,https://twitter.com/vozemberg,@vozemberg,Greece,Group of the European People's Party (Christian Democrats)
 Ellie CHOWNS,https://twitter.com/EllieChownsMEP,@EllieChownsMEP,United Kingdom,Group of the Greens/European Free Alliance
-Elsi KATAINEN,https://www-twitter.com/elsikatainen,@elsikatainen,Finland,Renew Europe Group
+Elsi KATAINEN,https://www.twitter.com/ElsiKatainen,@ElsiKatainen,Finland,Renew Europe Group
 Elżbieta Katarzyna ŁUKACIJEWSKA,https://twitter.com/elukacijewska,@elukacijewska,Poland,Group of the European People's Party (Christian Democrats)
 Elżbieta KRUK,,,Poland,European Conservatives and Reformists Group
-Elżbieta RAFALSKA,https://twitter.com/e_rafalska,@e_rafalska,Poland,European Conservatives and Reformists Group
-Emil RADEV,https://twitter.com/emil_radev,@emil_radev,Bulgaria,Group of the European People's Party (Christian Democrats)
+Elżbieta RAFALSKA,https://twitter.com/E_Rafalska,@E_Rafalska,Poland,European Conservatives and Reformists Group
+Emil RADEV,https://twitter.com/Emil_Radev,@Emil_Radev,Bulgaria,Group of the European People's Party (Christian Democrats)
 Emmanouil FRAGKOS,,,Greece,European Conservatives and Reformists Group
 Emmanuel MAUREL,https://twitter.com/emmanuelmaurel,@emmanuelmaurel,France,Confederal Group of the European United Left - Nordic Green Left
 Engin EROGLU,https://twitter.com/EnginEroglu_FW,@EnginEroglu_FW,Germany,Renew Europe Group
 Enikő GYŐRI,https://twitter.com/GyoriEniko,@GyoriEniko,Hungary,Group of the European People's Party (Christian Democrats)
 Eric ANDRIEU,https://twitter.com/EricAndrieuEU,@EricAndrieuEU,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Erik BERGKVIST,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Erik MARQUARDT,https://twitter.com/erikmarquardt,@erikmarquardt,Germany,Group of the Greens/European Free Alliance
+Erik MARQUARDT,https://twitter.com/ErikMarquardt,@ErikMarquardt,Germany,Group of the Greens/European Free Alliance
 Ernest URTASUN,https://twitter.com/ernesturtasun,@ernesturtasun,Spain,Group of the Greens/European Free Alliance
 Esteban GONZÁLEZ PONS,https://twitter.com/gonzalezpons,@gonzalezpons,Spain,Group of the European People's Party (Christian Democrats)
 Esther de LANGE,https://twitter.com/Esther_de_Lange,@Esther_de_Lange,Netherlands,Group of the European People's Party (Christian Democrats)
@@ -225,12 +225,12 @@ Evelyn REGNER,https://twitter.com/Evelyn_Regner,@Evelyn_Regner,Austria,Group of 
 Evelyne GEBHARDT,https://twitter.com/egebhardtMdEP,@egebhardtMdEP,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Evin INCIR,https://twitter.com/EvinIncir,@EvinIncir,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Evžen TOŠENOVSKÝ,https://twitter.com/EvzenTosenovsky,@EvzenTosenovsky,Czechia,European Conservatives and Reformists Group
-Ewa KOPACZ,https://twitter.com/ewakopacz,@ewakopacz,Poland,Group of the European People's Party (Christian Democrats)
+Ewa KOPACZ,https://twitter.com/EwaKopacz,@EwaKopacz,Poland,Group of the European People's Party (Christian Democrats)
 Fabienne KELLER,https://twitter.com/fabienne_keller,@fabienne_keller,France,Renew Europe Group
 Fabio Massimo CASTALDO,https://twitter.com/FMCastaldo,@FMCastaldo,Italy,Non-attached Members
 Filip DE MAN,,,Belgium,Identity and Democracy Group
 Franc BOGOVIČ,https://twitter.com/Franc_Bogovic,@Franc_Bogovic,Slovenia,Group of the European People's Party (Christian Democrats)
-France JAMET,https://twitter.com/francejamet,@francejamet,France,Identity and Democracy Group
+France JAMET,https://twitter.com/FranceJamet,@FranceJamet,France,Identity and Democracy Group
 Frances FITZGERALD,https://twitter.com/FitzgeraldFrncs,@FitzgeraldFrncs,Ireland,Group of the European People's Party (Christian Democrats)
 Francesca DONATO,https://twitter.com/ladyonorato,@ladyonorato,Italy,Identity and Democracy Group
 Francisco GUERREIRO,https://twitter.com/FGuerreiroMEP,@FGuerreiroMEP,Portugal,Group of the Greens/European Free Alliance
@@ -244,7 +244,7 @@ Fulvio MARTUSCIELLO,https://twitter.com/fulviomartuscie,@fulviomartuscie,Italy,G
 Gabriele BISCHOFF,https://twitter.com/gabischoff,@gabischoff,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Geert BOURGEOIS,https://twitter.com/GeertBourgeois,@GeertBourgeois,Belgium,European Conservatives and Reformists Group
 Geoffrey VAN ORDEN,https://twitter.com/GVOMEP,@GVOMEP,United Kingdom,European Conservatives and Reformists Group
-Geoffroy DIDIER,https://twitter.com/geoffroydidier,@geoffroydidier,France,Group of the European People's Party (Christian Democrats)
+Geoffroy DIDIER,https://twitter.com/GeoffroyDidier,@GeoffroyDidier,France,Group of the European People's Party (Christian Democrats)
 Georg MAYER,https://twitter.com/georgmayermep,@georgmayermep,Austria,Identity and Democracy Group
 Georgios KYRTSOS,https://twitter.com/GiorgosKyrtsos,@GiorgosKyrtsos,Greece,Group of the European People's Party (Christian Democrats)
 Gerolf ANNEMANS,https://twitter.com/gannemans,@gannemans,Belgium,Identity and Democracy Group
@@ -252,7 +252,7 @@ Gheorghe FALCĂ,,,Romania,Group of the European People's Party (Christian Democr
 Gianantonio DA RE,https://twitter.com/GianantonioDaRe,@GianantonioDaRe,Italy,Identity and Democracy Group
 Gianna GANCIA,https://twitter.com/giannagancia,@giannagancia,Italy,Identity and Democracy Group
 Gilbert COLLARD,https://twitter.com/GilbertCollard,@GilbertCollard,France,Identity and Democracy Group
-Gilles BOYER,https://twitter.com/gillesboyer,@gillesboyer,France,Renew Europe Group
+Gilles BOYER,https://twitter.com/GillesBoyer,@GillesBoyer,France,Renew Europe Group
 Gilles LEBRETON,https://twitter.com/Gilles_Lebreton,@Gilles_Lebreton,France,Identity and Democracy Group
 Gina DOWDING,https://twitter.com/GinaDowdingMEP,@GinaDowdingMEP,United Kingdom,Group of the Greens/European Free Alliance
 Giorgos GEORGIOU,,,Cyprus,Confederal Group of the European United Left - Nordic Green Left
@@ -264,7 +264,7 @@ Grzegorz TOBISZOWSKI,https://twitter.com/tobiszowski,@tobiszowski,Poland,Europea
 Guido REIL,https://twitter.com/GuidoReil,@GuidoReil,Germany,Identity and Democracy Group
 Gunnar BECK,,,Germany,Identity and Democracy Group
 Günther SIDL,,,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Guy VERHOFSTADT,https://twitter.com/GuyVerhofstadt,@GuyVerhofstadt,Belgium,Renew Europe Group
+Guy VERHOFSTADT,https://twitter.com/guyverhofstadt,@guyverhofstadt,Belgium,Renew Europe Group
 Gwendoline DELBOS-CORFIELD,https://twitter.com/GDelbosCorfield,@GDelbosCorfield,France,Group of the Greens/European Free Alliance
 György HÖLVÉNYI,https://twitter.com/HolvenyiGyorgy,@HolvenyiGyorgy,Hungary,Group of the European People's Party (Christian Democrats)
 Hannah NEUMANN,https://twitter.com/Hannah_LBerg,@Hannah_LBerg,Germany,Group of the Greens/European Free Alliance
@@ -285,18 +285,18 @@ Hilde VAUTMANS,https://twitter.com/hildevautmans,@hildevautmans,Belgium,Renew Eu
 Hildegard BENTELE,https://twitter.com/hildebentele,@hildebentele,Germany,Group of the European People's Party (Christian Democrats)
 Hynek BLAŠKO,,,Czechia,Identity and Democracy Group
 Ibán GARCÍA DEL BLANCO,https://twitter.com/Ibangarciadb,@Ibangarciadb,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Idoia VILLANUEVA RUIZ,https://twitter.com/idoiavr,@idoiavr,Spain,Confederal Group of the European United Left - Nordic Green Left
+Idoia VILLANUEVA RUIZ,https://twitter.com/IdoiaVR,@IdoiaVR,Spain,Confederal Group of the European United Left - Nordic Green Left
 Ignazio CORRAO,https://twitter.com/ignaziocorrao,@ignaziocorrao,Italy,Non-attached Members
 Ilhan KYUCHYUK,https://twitter.com/ilhankyuchyuk,@ilhankyuchyuk,Bulgaria,Renew Europe Group
-Inese VAIDERE,https://twitter.com/inesevaidere,@inesevaidere,Latvia,Group of the European People's Party (Christian Democrats)
+Inese VAIDERE,https://twitter.com/IneseVaidere,@IneseVaidere,Latvia,Group of the European People's Party (Christian Democrats)
 Inma RODRÍGUEZ-PIÑERO,https://twitter.com/RodriguezPinero,@RodriguezPinero,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Ioan-Rareş BOGDAN,,,Romania,Group of the European People's Party (Christian Democrats)
 Ioannis LAGOS,,,Greece,Non-attached Members
 Iratxe GARCÍA PÉREZ,https://twitter.com/IratxeGarper,@IratxeGarper,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Irena JOVEVA,https://twitter.com/ijoveva,@ijoveva,Slovenia,Renew Europe Group
+Irena JOVEVA,https://twitter.com/IJoveva,@Ijoveva,Slovenia,Renew Europe Group
 Irene TINAGLI,https://twitter.com/itinagli,@itinagli,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Irène TOLLERET,https://twitter.com/ITolleret,@ITolleret,France,Renew Europe Group
-Irina VON WIESE,https://twitter.com/irinavonwiese,@irinavonwiese,United Kingdom,Renew Europe Group
+Irina VON WIESE,https://twitter.com/IrinavonWiese,@IrinavonWiese,United Kingdom,Renew Europe Group
 Isabel BENJUMEA BENJUMEA,https://twitter.com/IsabelBenjumea,@IsabelBenjumea,Spain,Group of the European People's Party (Christian Democrats)
 Isabel CARVALHAIS,,,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Isabel GARCÍA MUÑOZ,,,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -315,13 +315,13 @@ Ivars IJABS,https://twitter.com/ijabs,@ijabs,Latvia,Renew Europe Group
 Ivo HRISTOV,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Izabela-Helena KLOC,https://twitter.com/IzabelaKloc,@IzabelaKloc,Poland,European Conservatives and Reformists Group
 Izaskun BILBAO BARANDICA,https://twitter.com/IzaskunBilbaoB,@IzaskunBilbaoB,Spain,Renew Europe Group
-Jaak MADISON,https://twitter.com/jaakmadison,@jaakmadison,Estonia,Identity and Democracy Group
+Jaak MADISON,https://twitter.com/JaakMadison,@JaakMadison,Estonia,Identity and Democracy Group
 Jacek SARYUSZ-WOLSKI,https://twitter.com/JSaryuszWolski,@JSaryuszWolski,Poland,European Conservatives and Reformists Group
 Jackie JONES,https://twitter.com/JackieJonesWal1,@JackieJonesWal1,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Jadwiga WIŚNIEWSKA,https://twitter.com/j_wisniewska,@j_wisniewska,Poland,European Conservatives and Reformists Group
 Jake PUGH,https://twitter.com/jake_pugh,@jake_pugh,United Kingdom,Non-attached Members
 James Alexander GLANCY,https://twitter.com/jaglancy,@jaglancy,United Kingdom,Non-attached Members
-James WELLS,https://twitter.com/jamesfwells,@jamesfwells,United Kingdom,Non-attached Members
+James WELLS,https://twitter.com/JamesfWells,@JamesfWells,United Kingdom,Non-attached Members
 Jan HUITEMA,https://twitter.com/jhuitema,@jhuitema,Netherlands,Renew Europe Group
 Jan OLBRYCHT,https://twitter.com/JanOlbrycht,@JanOlbrycht,Poland,Group of the European People's Party (Christian Democrats)
 Jan ZAHRADIL,https://twitter.com/ZahradilJan,@ZahradilJan,Czechia,European Conservatives and Reformists Group
@@ -329,7 +329,7 @@ Jan-Christoph OETJEN,https://twitter.com/jcoetjen,@jcoetjen,Germany,Renew Europe
 Jane BROPHY,https://twitter.com/JaneBrophyLD,@JaneBrophyLD,United Kingdom,Renew Europe Group
 Janina OCHOJSKA,https://twitter.com/JaninaOchojska,@JaninaOchojska,Poland,Group of the European People's Party (Christian Democrats)
 Janusz LEWANDOWSKI,https://twitter.com/J_Lewandowski,@J_Lewandowski,Poland,Group of the European People's Party (Christian Democrats)
-Jarosław DUDA,https://twitter.com/jaroslawduda,@jaroslawduda,Poland,Group of the European People's Party (Christian Democrats)
+Jarosław DUDA,https://twitter.com/JaroslawDuda,@JaroslawDuda,Poland,Group of the European People's Party (Christian Democrats)
 Jarosław KALINOWSKI,,,Poland,Group of the European People's Party (Christian Democrats)
 Javi LÓPEZ,https://twitter.com/fjavilopez,@fjavilopez,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Javier MORENO SÁNCHEZ,,,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -352,7 +352,7 @@ Joachim SCHUSTER,https://twitter.com/Schuster_MdEP,@Schuster_MdEP,Germany,Group 
 Joachim Stanisław BRUDZIŃSKI,https://twitter.com/jbrudzinski,@jbrudzinski,Poland,European Conservatives and Reformists Group
 Joanna KOPCIŃSKA,https://twitter.com/j_kopcinska,@j_kopcinska,Poland,European Conservatives and Reformists Group
 João FERREIRA,https://twitter.com/joao_ferreira33,@joao_ferreira33,Portugal,Confederal Group of the European United Left - Nordic Green Left
-Joëlle MÉLIN,https://twitter.com/joellemelinrn,@joellemelinrn,France,Identity and Democracy Group
+Joëlle MÉLIN,https://twitter.com/JoelleMelinRN,@JoelleMelinRN,France,Identity and Democracy Group
 Johan DANIELSSON,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Johan VAN OVERTVELDT,https://twitter.com/jvanovertveldt,@jvanovertveldt,Belgium,European Conservatives and Reformists Group
 John David Edward TENNANT,https://twitter.com/JohnTennantMEP,@JohnTennantMEP,United Kingdom,Non-attached Members
@@ -363,23 +363,23 @@ Jonathan BULLOCK,https://twitter.com/JonathanMEP,@JonathanMEP,United Kingdom,Non
 Jordan BARDELLA,https://twitter.com/J_Bardella,@J_Bardella,France,Identity and Democracy Group
 Jordi CAÑAS,https://twitter.com/jordi_canyas,@jordi_canyas,Spain,Renew Europe Group
 Jörg MEUTHEN,https://twitter.com/Joerg_Meuthen,@Joerg_Meuthen,Germany,Identity and Democracy Group
-Jorge BUXADÉ VILLALBA,https://twitter.com/jorgebuxade,@jorgebuxade,Spain,European Conservatives and Reformists Group
+Jorge BUXADÉ VILLALBA,https://twitter.com/Jorgebuxade,@Jorgebuxade,Spain,European Conservatives and Reformists Group
 Jörgen WARBORN,https://twitter.com/jorgenwarborn,@jorgenwarborn,Sweden,Group of the European People's Party (Christian Democrats)
 José GUSMÃO,https://www.twitter.com/joseggusmao,@joseggusmao,Portugal,Confederal Group of the European United Left - Nordic Green Left
 José Manuel FERNANDES,https://twitter.com/JMFernandesEU,@JMFernandesEU,Portugal,Group of the European People's Party (Christian Democrats)
 José Manuel GARCÍA-MARGALLO Y MARFIL,https://twitter.com/MargalloJm,@MargalloJm,Spain,Group of the European People's Party (Christian Democrats)
-José Ramón BAUZÁ DÍAZ,https://twitter.com/jrbauza,@jrbauza,Spain,Renew Europe Group
+José Ramón BAUZÁ DÍAZ,https://twitter.com/JRBauza,@JRBauza,Spain,Renew Europe Group
 Josianne CUTAJAR,https://twitter.com/josiannecutajar,@josiannecutajar,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 József SZÁJER,,,Hungary,Group of the European People's Party (Christian Democrats)
 Juan Fernando LÓPEZ AGUILAR,https://twitter.com/JFLopezAguilar,@JFLopezAguilar,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Juan Ignacio ZOIDO ÁLVAREZ,https://twitter.com/zoidoJI,@zoidoJI,Spain,Group of the European People's Party (Christian Democrats)
 Jude KIRTON-DARLING,https://twitter.com/Jude_KD,@Jude_KD,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Judith BUNTING,https://twitter.com/judithbuntingld,@judithbuntingld,United Kingdom,Renew Europe Group
+Judith BUNTING,https://twitter.com/JudithBuntingLD,@JudithBuntingLD,United Kingdom,Renew Europe Group
 Julie LECHANTEUX,https://twitter.com/JLechanteux,@JLechanteux,France,Identity and Democracy Group
 Julie WARD,https://twitter.com/julie4nw,@julie4nw,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 June Alison MUMMERY,https://twitter.com/june_mummery,@june_mummery,United Kingdom,Non-attached Members
 Juozas OLEKAS,https://twitter.com/juozas_olekas,@juozas_olekas,Lithuania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Jutta PAULUS,https://twitter.com/juttapaulusrlp,@juttapaulusrlp,Germany,Group of the Greens/European Free Alliance
+Jutta PAULUS,https://twitter.com/JuttaPaulusRLP,@JuttaPaulusRLP,Germany,Group of the Greens/European Free Alliance
 Jytte GUTELAND,https://twitter.com/JytteGuteland,@JytteGuteland,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Karen MELCHIOR,https://twitter.com/karmel80,@karmel80,Denmark,Renew Europe Group
 Karima DELLI,https://twitter.com/KarimaDelli,@KarimaDelli,France,Group of the Greens/European Free Alliance
@@ -388,14 +388,14 @@ Karlo RESSLER,https://twitter.com/KarloRessler,@KarloRessler,Croatia,Group of th
 Karol KARSKI,https://twitter.com/profKarski,@profKarski,Poland,European Conservatives and Reformists Group
 Karoline EDTSTADLER,https://twitter.com/k_edtstadler,@k_edtstadler,Austria,Group of the European People's Party (Christian Democrats)
 Katalin CSEH,https://twitter.com/katka_cseh,@katka_cseh,Hungary,Renew Europe Group
-Katarina BARLEY,https://twitter.com/KATARINABARLEY,@KATARINABARLEY,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Katarina BARLEY,https://twitter.com/katarinabarley,@katarinabarley,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Kateřina KONEČNÁ,https://twitter.com/Konecna_K,@Konecna_K,Czechia,Confederal Group of the European United Left - Nordic Green Left
 Kathleen VAN BREMPT,https://twitter.com/kvanbrempt,@kvanbrempt,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Kati PIRI,https://twitter.com/KatiPiri,@KatiPiri,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Katrin LANGENSIEPEN,https://twitter.com/k_langensiepen,@k_langensiepen,Germany,Group of the Greens/European Free Alliance
 Kim VAN SPARRENTAK,https://twitter.com/kimvsparrentak,@kimvsparrentak,Netherlands,Group of the Greens/European Free Alliance
 Kinga GÁL,,,Hungary,Group of the European People's Party (Christian Democrats)
-Kira Marie PETER-HANSEN,https://twitter.com/kira_mph,@kira_mph,Denmark,Group of the Greens/European Free Alliance
+Kira Marie PETER-HANSEN,https://twitter.com/Kira_MPH,@Kira_MPH,Denmark,Group of the Greens/European Free Alliance
 Klára DOBREV,,,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Klaus BUCHNER,https://twitter.com/Dr_KlausBuchner,@Dr_KlausBuchner,Germany,Group of the Greens/European Free Alliance
 Klemen GROŠELJ,https://twitter.com/KGroselj,@KGroselj,Slovenia,Renew Europe Group
@@ -403,11 +403,11 @@ Konstantinos ARVANITIS,,,Greece,Confederal Group of the European United Left - N
 Kosma ZŁOTOWSKI,https://twitter.com/KosmaZlotowski,@KosmaZlotowski,Poland,European Conservatives and Reformists Group
 Kostas PAPADAKIS,,,Greece,Non-attached Members
 Kris PEETERS,https://twitter.com/peeters_kris1,@peeters_kris1,Belgium,Group of the European People's Party (Christian Democrats)
-Krzysztof HETMAN,https://twitter.com/hetman_k,@hetman_k,Poland,Group of the European People's Party (Christian Democrats)
+Krzysztof HETMAN,https://twitter.com/Hetman_K,@Hetman_K,Poland,Group of the European People's Party (Christian Democrats)
 Krzysztof JURGIEL,,,Poland,European Conservatives and Reformists Group
 Lance FORMAN,https://twitter.com/LanceForman,@LanceForman,United Kingdom,Non-attached Members
 Lara WOLTERS,https://twitter.com/larawoltersEU,@larawoltersEU,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament 
-Lars Patrick BERG,https://www.twitter.com/larspatrickberg,@larspatrickberg,Germany,Identity and Democracy Group
+Lars Patrick BERG,https://www.twitter.com/LarsPatrickBerg,@LarsPatrickBerg,Germany,Identity and Democracy Group
 László TRÓCSÁNYI,https://twitter.com/trocsanyi,@trocsanyi,Hungary,Group of the European People's Party (Christian Democrats)
 Laura FERRARA,https://twitter.com/LFerraraM5S,@LFerraraM5S,Italy,Non-attached Members
 Laura HUHTASAARI,https://twitter.com/LauraHuhtasaari,@LauraHuhtasaari,Finland,Identity and Democracy Group
@@ -426,64 +426,64 @@ Lívia JÁRÓKA,https://twitter.com/JarokaLivia,@JarokaLivia,Hungary,Group of th
 Ljudmila NOVAK,https://twitter.com/LjudmilaNovak,@LjudmilaNovak,Slovenia,Group of the European People's Party (Christian Democrats)
 Loránt VINCZE,https://twitter.com/vinczelorant,@vinczelorant,Romania,Group of the European People's Party (Christian Democrats)
 Loucas FOURLAS,https://twitter.com/loucas_fourlas,@loucas_fourlas,Cyprus,Group of the European People's Party (Christian Democrats)
-Louis STEDMAN-BRYCE,https://twitter.com/lstedmanbryce,@lstedmanbryce,United Kingdom,Non-attached Members
+Louis STEDMAN-BRYCE,https://twitter.com/Lstedmanbryce,@Lstedmanbryce,United Kingdom,Non-attached Members
 Lucia ĎURIŠ NICHOLSONOVÁ,https://twitter.com/LNicholsonova,@LNicholsonova,Slovakia,European Conservatives and Reformists Group
 Lucia VUOLO,https://twitter.com/LuciaVuoloEU,@LuciaVuoloEU,Italy,Identity and Democracy Group
 Lucy Elizabeth HARRIS,https://twitter.com/Lugey6,@Lugey6,United Kingdom,Non-attached Members
-Lucy NETHSINGHA,https://twitter.com/lnethsingha,@lnethsingha,United Kingdom,Renew Europe Group
+Lucy NETHSINGHA,https://twitter.com/LNethsingha,@Lnethsingha,United Kingdom,Renew Europe Group
 Luděk NIEDERMAYER,https://twitter.com/LudekNie,@LudekNie,Czechia,Group of the European People's Party (Christian Democrats)
 Luis GARICANO,https://twitter.com/lugaricano,@lugaricano,Spain,Renew Europe Group
 Luisa PORRITT,https://twitter.com/LuisaPorritt,@LuisaPorritt,United Kingdom,Renew Europe Group
 Luisa REGIMENTI,https://twitter.com/luisaregimenti,@luisaregimenti,Italy,Identity and Democracy Group
 Lukas MANDL,https://twitter.com/lukasmandl,@lukasmandl,Austria,Group of the European People's Party (Christian Democrats)
-Łukasz KOHUT,https://twitter.com/lukaszkohut,@lukaszkohut,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Łukasz KOHUT,https://twitter.com/LukaszKohut,@LukaszKohut,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Luke Ming FLANAGAN,https://twitter.com/lukeming,@lukeming,Ireland,Confederal Group of the European United Left - Nordic Green Left
 Magdalena ADAMOWICZ,https://twitter.com/Adamowicz_Magda,@Adamowicz_Magda,Poland,Group of the European People's Party (Christian Democrats)
-Magid MAGID,https://twitter.com/magicmagid,@magicmagid,United Kingdom,Group of the Greens/European Free Alliance
+Magid MAGID,https://twitter.com/MagicMagid,@MagicMagid,United Kingdom,Group of the Greens/European Free Alliance
 Mairead McGUINNESS,https://twitter.com/MaireadMcGMEP,@MaireadMcGMEP,Ireland,Group of the European People's Party (Christian Democrats)
 Maite PAGAZAURTUNDÚA,https://twitter.com/maitepagaza,@maitepagaza,Spain,Renew Europe Group
 Malik AZMANI,https://twitter.com/MalikAzmani,@MalikAzmani,Netherlands,Renew Europe Group
 Malin BJÖRK,https://twitter.com/MalinBjork_EU,@MalinBjork_EU,Sweden,Confederal Group of the European United Left - Nordic Green Left
 Manfred WEBER,https://twitter.com/ManfredWeber,@ManfredWeber,Germany,Group of the European People's Party (Christian Democrats)
 Manolis KEFALOGIANNIS,https://twitter.com/M_Kefalogiannis,@M_Kefalogiannis,Greece,Group of the European People's Party (Christian Democrats)
-Manon AUBRY,https://twitter.com/manonaubryfr,@manonaubryfr,France,Confederal Group of the European United Left - Nordic Green Left
-Manu PINEDA,https://twitter.com/manu_abu_carlos,@manu_abu_carlos,Spain,Confederal Group of the European United Left - Nordic Green Left
+Manon AUBRY,https://twitter.com/ManonAubryFr,@ManonAubryFr,France,Confederal Group of the European United Left - Nordic Green Left
+Manu PINEDA,https://twitter.com/Manu_Abu_Carlos,@Manu_Abu_Carlos,Spain,Confederal Group of the European United Left - Nordic Green Left
 Manuel BOMPARD,https://twitter.com/mbompard,@mbompard,France,Confederal Group of the European United Left - Nordic Green Left
 Manuel PIZARRO,https://twitter.com/MPizarroPorto,@MPizarroPorto,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Mara BIZZOTTO,https://twitter.com/marabizzotto,@marabizzotto,Italy,Identity and Democracy Group
-Marc BOTENGA,https://www.twitter.com/botengam,@botengam,Belgium,Confederal Group of the European United Left - Nordic Green Left
+Marc BOTENGA,https://www.twitter.com/BotengaM,@BotengaM,Belgium,Confederal Group of the European United Left - Nordic Green Left
 Marc TARABELLA,https://twitter.com/marctarabella,@marctarabella,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Marcel KOLAJA,https://twitter.com/PiratKolaja,@PiratKolaja,Czechia,Group of the Greens/European Free Alliance
-Marco CAMPOMENOSI,https://twitter.com/mcampomenosi,@mcampomenosi,Italy,Identity and Democracy Group
+Marco CAMPOMENOSI,https://twitter.com/MCampomenosi,@Mcampomenosi,Italy,Identity and Democracy Group
 Marco DREOSTO,https://twitter.com/MarcoDreosto,@MarcoDreosto,Italy,Identity and Democracy Group
 Marco ZANNI,https://twitter.com/Marcozanni86,@Marcozanni86,Italy,Identity and Democracy Group
 Marco ZULLO,https://twitter.com/MarcoZullo,@MarcoZullo,Italy,Non-attached Members
 Marek BELKA,https://twitter.com/profMarekBelka,@profMarekBelka,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Marek Paweł BALT,https://twitter.com/poselbalt,@poselbalt,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Marek Paweł BALT,https://twitter.com/PoselBalt,@PoselBalt,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Margarida MARQUES,https://twitter.com/mmargmarques,@mmargmarques,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Margrete AUKEN,https://twitter.com/MargreteAuken,@MargreteAuken,Denmark,Group of the Greens/European Free Alliance
 Maria ARENA,https://twitter.com/Mariearenaps,@Mariearenaps,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Maria Da Graça CARVALHO,https://twitter.com/mgracacarvalho,@mgracacarvalho,Portugal,Group of the European People's Party (Christian Democrats)
-Maria GRAPINI,https://twitter.com/mariagrapini,@mariagrapini,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Maria Manuel LEITÃO MARQUES,https://twitter.com/mariamanuellm,@mariamanuellm,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Maria GRAPINI,https://twitter.com/MariaGrapini,@MariaGrapini,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Maria Manuel LEITÃO MARQUES,https://twitter.com/MariaManuelLM,@MariaManuelLM,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Maria NOICHL,https://twitter.com/MariaNoichl,@MariaNoichl,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 María Soraya RODRÍGUEZ RAMOS,https://twitter.com/sorayarr_,@sorayarr_,Spain,Renew Europe Group
 Maria SPYRAKI,https://twitter.com/MariaSpyraki,@MariaSpyraki,Greece,Group of the European People's Party (Christian Democrats)
-Maria WALSH,https://twitter.com/mariawalsheu,@mariawalsheu,Ireland,Group of the European People's Party (Christian Democrats)
+Maria WALSH,https://twitter.com/MariaWalshEU,@MariaWalshEU,Ireland,Group of the European People's Party (Christian Democrats)
 Marian-Jean MARINESCU,https://twitter.com/MarianMarinescu,@MarianMarinescu,Romania,Group of the European People's Party (Christian Democrats)
 Marianne VIND,https://twitter.com/MarianneVind,@MarianneVind,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Marie TOUSSAINT,https://twitter.com/marietouss1,@marietouss1,France,Group of the Greens/European Free Alliance
-Marie-Pierre VEDRENNE,https://twitter.com/mariepierrev,@mariepierrev,France,Renew Europe Group
+Marie-Pierre VEDRENNE,https://twitter.com/MariePierreV,@MariePierreV,France,Renew Europe Group
 Marina KALJURAND,https://twitter.com/MarinaKaljurand,@MarinaKaljurand,Estonia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Mario FURORE,https://twitter.com/MarioFurore,@MarioFurore,Italy,Non-attached Members
-Marion WALSMANN,https://twitter.com/marionwalsmann,@marionwalsmann,Germany,Group of the European People's Party (Christian Democrats)
+Marion WALSMANN,https://twitter.com/MarionWalsmann,@MarionWalsmann,Germany,Group of the European People's Party (Christian Democrats)
 Marisa MATIAS,https://twitter.com/mmatias_,@mmatias_,Portugal,Confederal Group of the European United Left - Nordic Green Left
 Markéta GREGOROVÁ,https://twitter.com/MarketkaG,@MarketkaG,Czechia,Group of the Greens/European Free Alliance
 Markus BUCHHEIT,https://twitter.com/BuchheitMarkus,@BuchheitMarkus,Germany,Identity and Democracy Group
 Markus FERBER,https://twitter.com/MarkusFerber,@MarkusFerber,Germany,Group of the European People's Party (Christian Democrats)
-Markus PIEPER,https://twitter.com/markuspiepermep,@markuspiepermep,Germany,Group of the European People's Party (Christian Democrats)
+Markus PIEPER,https://twitter.com/markuspieperMEP,@markuspieperMEP,Germany,Group of the European People's Party (Christian Democrats)
 Marlene MORTLER,,,Germany,Group of the European People's Party (Christian Democrats)
-Martin BUSCHMANN,https://twitter.com/buschmannmartin,@buschmannmartin,Germany,Confederal Group of the European United Left - Nordic Green Left
+Martin BUSCHMANN,https://twitter.com/BuschmannMartin,@BuschmannMartin,Germany,Confederal Group of the European United Left - Nordic Green Left
 Martin Edward DAUBNEY,https://twitter.com/MartinDaubney,@MartinDaubney,United Kingdom,Non-attached Members
 Martin HÄUSLING,https://twitter.com/MartinHaeusling,@MartinHaeusling,Germany,Group of the Greens/European Free Alliance
 Martin HLAVÁČEK,,,Czechia,Renew Europe Group
@@ -504,12 +504,12 @@ Matteo ADINOLFI,https://twitter.com/adinolfi_matteo,@adinolfi_matteo,Italy,Ident
 Matthew PATTEN,https://twitter.com/math_patten,@math_patten,United Kingdom,Non-attached Members
 Mauri PEKKARINEN,https://twitter.com/PekkarinenMauri,@PekkarinenMauri,Finland,Renew Europe Group
 Maxette PIRBAKAS,,,France,Identity and Democracy Group
-Maximilian KRAH,https://twitter.com/krahmax,@krahmax,Germany,Identity and Democracy Group
+Maximilian KRAH,https://twitter.com/KrahMax,@KrahMax,Germany,Identity and Democracy Group
 Mazaly AGUILAR,https://twitter.com/MazalyAguilar,@MazalyAguilar,Spain,European Conservatives and Reformists Group
 Miapetra KUMPULA-NATRI,https://twitter.com/miapetrakumpula,@miapetrakumpula,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Michael BLOSS,https://twitter.com/michabl,@michabl,Germany,Group of the Greens/European Free Alliance
 Michael GAHLER,https://twitter.com/michaelgahler,@michaelgahler,Germany,Group of the European People's Party (Christian Democrats)
-Michael HEAVER,https://twitter.com/michael_heaver,@michael_heaver,United Kingdom,Non-attached Members
+Michael HEAVER,https://twitter.com/Michael_Heaver,@Michael_Heaver,United Kingdom,Non-attached Members
 Michaela ŠOJDROVÁ,https://twitter.com/msojdrova,@msojdrova,Czechia,Group of the European People's Party (Christian Democrats)
 Michal ŠIMEČKA,,,Slovakia,Renew Europe Group
 Michal WIEZIK,,,Slovakia,Group of the European People's Party (Christian Democrats)
@@ -534,9 +534,9 @@ Monika BEŇOVÁ,https://twitter.com/monika_benova,@monika_benova,Slovakia,Group 
 Monika HOHLMEIER,https://twitter.com/MHohlmeier,@MHohlmeier,Germany,Group of the European People's Party (Christian Democrats)
 Monika VANA,https://twitter.com/MonikaVana,@MonikaVana,Austria,Group of the Greens/European Free Alliance
 Moritz KÖRNER,https://twitter.com/moritzkoerner,@moritzkoerner,Germany,Renew Europe Group
-Morten LØKKEGAARD,https://twitter.com/loekkegaard_mep,@loekkegaard_mep,Denmark,Renew Europe Group
+Morten LØKKEGAARD,https://twitter.com/Loekkegaard_MEP,@Loekkegaard_MEP,Denmark,Renew Europe Group
 Morten PETERSEN,https://twitter.com/mortenhelveg,@mortenhelveg,Denmark,Renew Europe Group
-Mounir SATOURI,https://twitter.com/mounirsatouri,@mounirsatouri,France,Group of the Greens/European Free Alliance
+Mounir SATOURI,https://twitter.com/MounirSatouri,@MounirSatouri,France,Group of the Greens/European Free Alliance
 Nacho SÁNCHEZ AMOR,https://twitter.com/NachoSAmor,@NachoSAmor,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nadine MORANO,https://twitter.com/nadine__morano,@nadine__morano,France,Group of the European People's Party (Christian Democrats)
 Naomi LONG,https://twitter.com/naomi_long,@naomi_long,United Kingdom,Renew Europe Group
@@ -548,7 +548,7 @@ Niclas HERBST,,,Germany,Group of the European People's Party (Christian Democrat
 Nico SEMSROTT,https://www.twitter.com/nicosemsrott,@nicosemsrott,Germany,Group of the Greens/European Free Alliance
 Nicola BEER,https://twitter.com/nicolabeerfdp,@nicolabeerfdp,Germany,Renew Europe Group
 Nicola DANTI,https://twitter.com/DantiNicola,@DantiNicola,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Nicola PROCACCINI,https://twitter.com/nprocaccini,@Nprocaccini,Italy,European Conservatives and Reformists Group
+Nicola PROCACCINI,https://twitter.com/NProcaccini,@Nprocaccini,Italy,European Conservatives and Reformists Group
 Nicolae ŞTEFĂNUȚĂ,https://twitter.com/nicustefanuta,@nicustefanuta,Romania,Renew Europe Group
 Nicolas BAY,https://twitter.com/NicolasBay_,@NicolasBay_,France,Identity and Democracy Group
 Nicolás GONZÁLEZ CASARES,https://twitter.com/nicogoncas,@nicogoncas,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -559,7 +559,7 @@ Nigel FARAGE,https://twitter.com/Nigel_Farage,@Nigel_Farage,United Kingdom,Non-a
 Niklas NIENASS,https://twitter.com/nnienass,@nnienass,Germany,Group of the Greens/European Free Alliance
 Nikolaj VILLUMSEN,https://twitter.com/nvillumsen,@nvillumsen,Denmark,Confederal Group of the European United Left - Nordic Green Left
 Nikos ANDROULAKIS,https://twitter.com/androulakisnick,@androulakisnick,Greece,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Nils TORVALDS,https://twitter.com/nilstorvalds,@nilstorvalds,Finland,Renew Europe Group
+Nils TORVALDS,https://twitter.com/NilsTorvalds,@NilsTorvalds,Finland,Renew Europe Group
 Nils UŠAKOVS,https://twitter.com/nilsusakovs,@nilsusakovs,Latvia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Niyazi KIZILYÜREK,https://twitter.com/NKizilyurek,@NKizilyurek,Cyprus,Confederal Group of the European United Left - Nordic Green Left
 Norbert LINS,,,Germany,Group of the European People's Party (Christian Democrats)
@@ -569,13 +569,13 @@ Nuno MELO,https://twitter.com/NunoMeloCDS,@NunoMeloCDS,Portugal,Group of the Eur
 Olivier CHASTEL,https://twitter.com/OChastel,@OChastel,Belgium,Renew Europe Group
 Ondřej KNOTEK,https://twitter.com/KnotekOndrej,@KnotekOndrej,Czechia,Renew Europe Group
 Ondřej KOVAŘÍK,https://twitter.com/OKovarikMEP,@OkovarikMEP,Czechia,Renew Europe Group
-Danilo Oscar LANCINI,https://twitter.com/doscarlancini,@doscarlancini,Italy,Identity and Democracy Group
+Danilo Oscar LANCINI,https://twitter.com/DOscarLancini,@DoscarLancini,Italy,Identity and Democracy Group
 Othmar KARAS,https://twitter.com/othmar_karas,@othmar_karas,Austria,Group of the European People's Party (Christian Democrats)
-Özlem DEMIREL,https://twitter.com/oezlemademirel,@oezlemademirel,Germany,Confederal Group of the European United Left - Nordic Green Left
+Özlem DEMIREL,https://twitter.com/OezlemADemirel,@OezlemADemirel,Germany,Confederal Group of the European United Left - Nordic Green Left
 Pablo ARIAS ECHEVERRÍA,,,Spain,Group of the European People's Party (Christian Democrats)
-Paolo BORCHIA,https://twitter.com/paoloborchia,@paoloborchia,Italy,Identity and Democracy Group
+Paolo BORCHIA,https://twitter.com/PaoloBorchia,@PaoloBorchia,Italy,Identity and Democracy Group
 Paolo DE CASTRO,https://twitter.com/paolodecastro,@paolodecastro,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Pär HOLMGREN,https://twitter.com/parholmgren,@parholmgren,Sweden,Group of the Greens/European Free Alliance
+Pär HOLMGREN,https://twitter.com/ParHolmgren,@ParHolmgren,Sweden,Group of the Greens/European Free Alliance
 Pascal ARIMONT,https://twitter.com/pascal_arimont,@pascal_arimont,Belgium,Group of the European People's Party (Christian Democrats)
 Pascal CANFIN,https://twitter.com/pcanfin,@pcanfin,France,Renew Europe Group
 Pascal DURAND,https://twitter.com/PDurandOfficiel,@PDurandOfficiel,France,Renew Europe Group
@@ -583,7 +583,7 @@ Patrick BREYER,https://twitter.com/echo_pbreyer,@echo_pbreyer,Germany,Group of t
 Patrizia TOIA,https://twitter.com/toiapatrizia,@toiapatrizia,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Patryk JAKI,https://twitter.com/PatrykJaki,@PatrykJaki,Poland,European Conservatives and Reformists Group
 Paul TANG,https://twitter.com/paultang,@paultang,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Paulo RANGEL,https://twitter.com/paulorangel_pt,@paulorangel_pt,Portugal,Group of the European People's Party (Christian Democrats)
+Paulo RANGEL,https://twitter.com/PauloRangel_pt,@PauloRangel_pt,Portugal,Group of the European People's Party (Christian Democrats)
 Pedro MARQUES,https://twitter.com/pmdjmarques,@pmdjmarques,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pedro SILVA PEREIRA,,,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pernando BARRENA ARZA,https://twitter.com/pernandobarrena,@pernandobarrena,Spain,Confederal Group of the European United Left - Nordic Green Left
@@ -616,35 +616,35 @@ Predrag Fred MATIĆ,https://twitter.com/fred_matic,@fred_matic,Croatia,Group of 
 Radan KANEV,https://twitter.com/rmkanev,@rmkanev,Bulgaria,Group of the European People's Party (Christian Democrats)
 Radka MAXOVÁ,https://twitter.com/radkamaxova,@radkamaxova,Czechia,Renew Europe Group
 Radosław SIKORSKI,https://twitter.com/sikorskiradek,@sikorskiradek,Poland,Group of the European People's Party (Christian Democrats)
-Raffaele FITTO,https://twitter.com/raffaelefitto,@raffaelefitto,Italy,European Conservatives and Reformists Group
+Raffaele FITTO,https://twitter.com/RaffaeleFitto,@RaffaeleFitto,Italy,European Conservatives and Reformists Group
 Raffaele STANCANELLI,https://twitter.com/r_stancanelli,@r_stancanelli,Italy,European Conservatives and Reformists Group
 Rainer WIELAND,,,Germany,Group of the European People's Party (Christian Democrats)
 Ralf SEEKATZ,,,Germany,Group of the European People's Party (Christian Democrats)
 Ramona STRUGARIU,https://twitter.com/RamonaStrugariu,@RamonaStrugariu,Romania,Renew Europe Group
 Raphaël GLUCKSMANN,https://twitter.com/rglucks1,@rglucks1,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Rasa JUKNEVIČIENĖ,https://twitter.com/rjukneviciene,@rjukneviciene,Lithuania,Group of the European People's Party (Christian Democrats)
+Rasa JUKNEVIČIENĖ,https://twitter.com/RJukneviciene,@Rjukneviciene,Lithuania,Group of the European People's Party (Christian Democrats)
 Rasmus ANDRESEN,https://twitter.com/RasmusAndresen,@RasmusAndresen,Germany,Group of the Greens/European Free Alliance
 Reinhard BÜTIKOFER,https://twitter.com/bueti,@bueti,Germany,Group of the Greens/European Free Alliance
 Richard CORBETT,https://twitter.com/RCorbettMEP,@RCorbettMEP,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Richard TICE,https://twitter.com/TiceRichard,@TiceRichard,United Kingdom,Non-attached Members
 Rob ROOKEN,https://twitter.com/rooken,@rooken,Netherlands,European Conservatives and Reformists Group
-Robert BIEDROŃ,https://twitter.com/robertbiedron,@robertbiedron,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Robert BIEDROŃ,https://twitter.com/RobertBiedron,@RobertBiedron,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Robert HAJŠEL,https://twitter.com/RobertHajsel,@RobertHajsel,Slovakia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Robert ROOS,https://twitter.com/rob_roos,@rob_roos,Netherlands,European Conservatives and Reformists Group
+Robert ROOS,https://twitter.com/Rob_Roos,@Rob_Roos,Netherlands,European Conservatives and Reformists Group
 Robert ROWLAND,https://twitter.com/RowlandBrexitSE,@RowlandBrexitSE,United Kingdom,Non-attached Members
 Roberta METSOLA,https://twitter.com/RobertaMetsola,@RobertaMetsola,Malta,Group of the European People's Party (Christian Democrats)
 Roberts ZĪLE,https://twitter.com/robertszile,@robertszile,Latvia,European Conservatives and Reformists Group
 Roman HAIDER,,,Austria,Identity and Democracy Group
 Romana TOMC,https://twitter.com/RomanaTomc,@RomanaTomc,Slovenia,Group of the European People's Party (Christian Democrats)
-Romeo FRANZ,https://twitter.com/romeofranz1,@romeofranz1,Germany,Group of the Greens/European Free Alliance
-Rory PALMER,https://twitter.com/rory_palmer,@rory_palmer,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Romeo FRANZ,https://twitter.com/RomeoFranz1,@RomeoFranz1,Germany,Group of the Greens/European Free Alliance
+Rory PALMER,https://twitter.com/Rory_Palmer,@Rory_Palmer,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Rosa D'AMATO,https://twitter.com/rosadamato634,@rosadamato634,Italy,Non-attached Members
 Rosa ESTARÀS FERRAGUT,,,Spain,Group of the European People's Party (Christian Democrats)
 Rosanna CONTE,https://twitter.com/Rosannaconte_,@Rosannaconte_,Italy,Identity and Democracy Group
 Rovana PLUMB,https://twitter.com/RovanaPlumbMM,@RovanaPlumbMM,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Róża THUN UND HOHENSTEIN,https://twitter.com/rozathun,@rozathun,Poland,Group of the European People's Party (Christian Democrats)
 Rupert LOWE,https://twitter.com/RupertLowe10,@RupertLowe10,United Kingdom,Non-attached Members
-Ruža TOMAŠIĆ,https://twitter.com/ruzatomasic,@ruzatomasic,Croatia,European Conservatives and Reformists Group
+Ruža TOMAŠIĆ,https://twitter.com/RuzaTomasic,@RuzaTomasic,Croatia,European Conservatives and Reformists Group
 Ryszard Antoni LEGUTKO,,,Poland,European Conservatives and Reformists Group
 Ryszard CZARNECKI,https://twitter.com/r_czarnecki,@r_czarnecki,Poland,European Conservatives and Reformists Group
 Sabine VERHEYEN,https://twitter.com/sabineverheyen,@sabineverheyen,Germany,Group of the European People's Party (Christian Democrats)
@@ -652,7 +652,7 @@ Sabrina PIGNEDOLI,https://twitter.com/SabriPignedoli,@SabriPignedoli,Italy,Non-a
 Salima YENBOU,https://twitter.com/salima_yenbou,@salima_yenbou,France,Group of the Greens/European Free Alliance
 Samira RAFAELA,https://twitter.com/samiraraf,@samiraraf,Netherlands,Renew Europe Group
 Sándor RÓNAI,https://twitter.com/sandor_ronai,@sandor_ronai,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Sandra KALNIETE,https://twitter.com/kalniete,@kalniete,Latvia,Group of the European People's Party (Christian Democrats)
+Sandra KALNIETE,https://twitter.com/Kalniete,@Kalniete,Latvia,Group of the European People's Party (Christian Democrats)
 Sandra PEREIRA,,,Portugal,Confederal Group of the European United Left - Nordic Green Left
 Sara CERDAS,https://twitter.com/sara_saracerdas,@sara_saracerdas,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sara SKYTTEDAL,https://twitter.com/skyttedal,@skyttedal,Sweden,Group of the European People's Party (Christian Democrats)
@@ -662,7 +662,7 @@ Scott AINSLIE,https://twitter.com/ScottMEPLondon,@ScottMEPLondon,United Kingdom,
 Seán KELLY,https://twitter.com/SeanKellyMEP,@SeanKellyMEP,Ireland,Group of the European People's Party (Christian Democrats)
 Seb DANCE,https://twitter.com/SebDance,@SebDance,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sergei STANISHEV,https://twitter.com/SergeiStanishev,@SergeiStanishev,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Sergey LAGODINSKY,https://twitter.com/slagodinsky,@slagodinsky,Germany,Group of the Greens/European Free Alliance
+Sergey LAGODINSKY,https://twitter.com/SLagodinsky,@Slagodinsky,Germany,Group of the Greens/European Free Alliance
 Shaffaq MOHAMMED,https://twitter.com/shaffaqmohd,@shaffaqmohd,United Kingdom,Renew Europe Group
 Sheila RITCHIE,https://twitter.com/europesheila,@europesheila,United Kingdom,Renew Europe Group
 Siegfried MUREŞAN,https://twitter.com/SMuresan,@SMuresan,Romania,Group of the European People's Party (Christian Democrats)
@@ -672,7 +672,7 @@ Silvio BERLUSCONI,https://twitter.com/berlusconi,@berlusconi,Italy,Group of the 
 Simona BALDASSARRE,https://twitter.com/SR_Baldassarre,@SR_Baldassarre,Italy,Identity and Democracy Group
 Simona BONAFÈ,https://twitter.com/simonabonafe,@simonabonafe,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Simone SCHMIEDTBAUER,,,Austria,Group of the European People's Party (Christian Democrats)
-Sira REGO,https://twitter.com/SIRAREGO,@SIRAREGO,Spain,Confederal Group of the European United Left - Nordic Green Left
+Sira REGO,https://twitter.com/sirarego,@sirarego,Spain,Confederal Group of the European United Left - Nordic Green Left
 Sirpa PIETIKÄINEN,https://twitter.com/spietikainen,@spietikainen,Finland,Group of the European People's Party (Christian Democrats)
 Ska KELLER,https://twitter.com/SkaKeller,@SkaKeller,Germany,Group of the Greens/European Free Alliance
 Sophia in 't VELD,https://twitter.com/SophieintVeld,@SophieintVeld,Netherlands,Renew Europe Group
@@ -682,7 +682,7 @@ Stasys JAKELIŪNAS,,,Lithuania,Group of the Greens/European Free Alliance
 Stefan BERGER,https://twitter.com/DrStefanBerger,@DrStefanBerger,Germany,Group of the European People's Party (Christian Democrats)
 Stefania ZAMBELLI,https://twitter.com/ZambelliLega,@ZambelliLega,Italy,Identity and Democracy Group
 Stelios KOULOGLOU,https://twitter.com/SteliosKoul,@SteliosKoul,Greece,Confederal Group of the European United Left - Nordic Green Left
-Stelios KYMPOUROPOULOS,https://twitter.com/kympouropoulos,@kympouropoulos,Greece,Group of the European People's Party (Christian Democrats)
+Stelios KYMPOUROPOULOS,https://twitter.com/Kympouropoulos,@Kympouropoulos,Greece,Group of the European People's Party (Christian Democrats)
 Stéphane BIJOUX,https://twitter.com/StephaneBIJOUX,@StephaneBIJOUX,France,Renew Europe Group
 Stéphane SÉJOURNÉ,https://twitter.com/steph_sejourne,@steph_sejourne,France,Renew Europe Group
 Stéphanie YON-COURTIN,https://twitter.com/s_yoncourtin,@s_yoncourtin,France,Renew Europe Group
@@ -696,7 +696,7 @@ Svenja HAHN,https://twitter.com/svenja_hahn,@svenja_hahn,Germany,Renew Europe Gr
 Sylvia LIMMER,,,Germany,Identity and Democracy Group
 Sylvie BRUNET,https://twitter.com/syl_brunet,@syl_brunet,France,Renew Europe Group
 Sylvie GUILLAUME,https://twitter.com/sylvieguillaume,@sylvieguillaume,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Sylwia SPUREK,https://twitter.com/sylwiaspurek,@sylwiaspurek,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Sylwia SPUREK,https://twitter.com/SylwiaSpurek,@SylwiaSpurek,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tamás DEUTSCH,https://twitter.com/dajcstomi,@dajcstomi,Hungary,Group of the European People's Party (Christian Democrats)
 Tanja FAJON,https://twitter.com/tfajon,@tfajon,Slovenia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tatjana ŽDANOKA,https://twitter.com/Tatjana_Zdanoka,@Tatjana_Zdanoka,Latvia,Group of the Greens/European Free Alliance
@@ -704,10 +704,10 @@ Terry REINTKE,https://twitter.com/TerryReintke,@TerryReintke,Germany,Group of th
 Teuvo HAKKARAINEN,,,Finland,Identity and Democracy Group
 Theodoros ZAGORAKIS,,,Greece,Group of the European People's Party (Christian Democrats)
 Theresa GRIFFIN,https://twitter.com/TheresaMEP,@TheresaMEP,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Thierry MARIANI,https://twitter.com/thierrymariani,@thierrymariani,France,Identity and Democracy Group
+Thierry MARIANI,https://twitter.com/ThierryMARIANI,@ThierryMARIANI,France,Identity and Democracy Group
 Tiemo WÖLKEN,https://twitter.com/woelken,@woelken,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tilly METZ,,,Luxembourg,Group of the Greens/European Free Alliance
-Tineke STRIK,https://twitter.com/tineke_strik,@tineke_strik,Netherlands,Group of the Greens/European Free Alliance
+Tineke STRIK,https://twitter.com/Tineke_Strik,@Tineke_Strik,Netherlands,Group of the Greens/European Free Alliance
 Tiziana BEGHIN,https://twitter.com/beghin_t,@beghin_t,Italy,Non-attached Members
 Tom BERENDSEN,https://twitter.com/tbwberendsen,@tbwberendsen,Netherlands,Group of the European People's Party (Christian Democrats)
 Tom VANDENDRIESSCHE,https://twitter.com/TomVandendriess,@TomVandendriess,Belgium,Identity and Democracy Group
@@ -721,11 +721,11 @@ Traian BĂSESCU,https://twitter.com/tbasescu,@tbasescu,Romania,Group of the Euro
 Tsvetelina PENKOVA,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tudor CIUHODARU,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Udo BULLMANN,https://twitter.com/UdoBullmann,@UdoBullmann,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Ulrike MÜLLER,https://twitter.com/ulimuellermdep,@ulimuellermdep,Germany,Renew Europe Group
-Urmas PAET,https://twitter.com/urmaspaet,@urmaspaet,Estonia,Renew Europe Group
+Ulrike MÜLLER,https://twitter.com/UliMuellerMdEP,@UliMuellerMdEP,Germany,Renew Europe Group
+Urmas PAET,https://twitter.com/Urmaspaet,@Urmaspaet,Estonia,Renew Europe Group
 Valdemar TOMAŠEVSKI,,,Lithuania,European Conservatives and Reformists Group
 Valentino GRANT,https://twitter.com/ValentinoGrant,@ValentinoGrant,Italy,Identity and Democracy Group
-Valerie HAYER,https://twitter.com/valeriehayer,@valeriehayer,France,Renew Europe Group
+Valerie HAYER,https://twitter.com/ValerieHayer,@ValerieHayer,France,Renew Europe Group
 Valter FLEGO,https://twitter.com/ValterFlego,@ValterFlego,Croatia,Renew Europe Group
 Vangelis MEIMARAKIS,https://twitter.com/v_meimarakis,@v_meimarakis,Greece,Group of the European People's Party (Christian Democrats)
 Vasile BLAGA,,,Romania,Group of the European People's Party (Christian Democrats)
@@ -734,16 +734,16 @@ Veronika VRECIONOVÁ,,,Czechia,European Conservatives and Reformists Group
 Véronique TRILLET-LENOIR,https://twitter.com/VTrillet_Lenoir,@VTrillet_Lenoir,France,Renew Europe Group
 Viktor USPASKICH,https://twitter.com/ViktorUspaskich,@ViktorUspaskich,Lithuania,Renew Europe Group
 Vilija BLINKEVIČIŪTĖ,,,Lithuania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Ville NIINISTÖ,https://www.twitter.com/villeniinisto,@villeniinisto,Finland,Group of the Greens/European Free Alliance
-Viola VON CRAMON-TAUBADEL,https://twitter.com/violavoncramon,@violavoncramon,Germany,Group of the Greens/European Free Alliance
+Ville NIINISTÖ,https://www.twitter.com/VilleNiinisto,@VilleNiinisto,Finland,Group of the Greens/European Free Alliance
+Viola VON CRAMON-TAUBADEL,https://twitter.com/ViolavonCramon,@ViolavonCramon,Germany,Group of the Greens/European Free Alliance
 Virginie JORON,https://twitter.com/v_joron,@v_joron,France,Identity and Democracy Group
 Vlad-Marius BOTOŞ,,,Romania,Renew Europe Group
-Vladimír BILČÍK,https://twitter.com/vladobilcik,@vladobilcik,Slovakia,Group of the European People's Party (Christian Democrats)
+Vladimír BILČÍK,https://twitter.com/VladoBilcik,@VladoBilcik,Slovakia,Group of the European People's Party (Christian Democrats)
 Witold Jan WASZCZYKOWSKI,https://twitter.com/WaszczykowskiW,@WaszczykowskiW,Poland,European Conservatives and Reformists Group
 Włodzimierz CIMOSZEWICZ,,,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Yana TOOM,https://twitter.com/yanatoom,@yanatoom,Estonia,Renew Europe Group
+Yana TOOM,https://twitter.com/YanaToom,@YanaToom,Estonia,Renew Europe Group
 Yannick JADOT,https://twitter.com/yjadot,@yjadot,France,Group of the Greens/European Free Alliance
 Younous OMARJEE,https://twitter.com/younousomarjee,@younousomarjee,France,Confederal Group of the European United Left - Nordic Green Left
-Zbigniew KUŹMIUK,https://twitter.com/zbigniewkuzmiuk,@zbigniewkuzmiuk,Poland,European Conservatives and Reformists Group
+Zbigniew KUŹMIUK,https://twitter.com/ZbigniewKuzmiuk,@ZbigniewKuzmiuk,Poland,European Conservatives and Reformists Group
 Zdzisław KRASNODĘBSKI,https://twitter.com/ZdzKrasnodebski,@ZdzKrasnodebski,Poland,European Conservatives and Reformists Group
 Željana ZOVKO,https://twitter.com/ZovkoEU,@ZovkoEU,Croatia,Group of the European People's Party (Christian Democrats)

--- a/meps_full_list_with_twitter_accounts.csv
+++ b/meps_full_list_with_twitter_accounts.csv
@@ -28,7 +28,7 @@ Alicia HOMS GINEL,https://twitter.com/aliciahoms,@aliciahoms,Spain,Group of the 
 Alyn SMITH,https://twitter.com/AlynSmith,@AlynSmith,United Kingdom,Group of the Greens/European Free Alliance
 Andor DELI,https://twitter.com/andordeli,@andordeli,Hungary,Group of the European People's Party (Christian Democrats)
 András GYÜRK,,,Hungary,Group of the European People's Party (Christian Democrats)
-André ROUGÉ,https://twitter.com/RougAndr1,@RougAndr1,France,Identity and Democracy Group
+André ROUGÉ,https://twitter.com/AndreRougeOff,@AndreRougeOff,France,Identity and Democracy Group
 Andrea BOCSKOR,https://twitter.com/AndreaBocskor,@AndreaBocskor,Hungary,Group of the European People's Party (Christian Democrats)
 Andrea CAROPPO,https://twitter.com/caroppo_andrea,@caroppo_andrea,Italy,Identity and Democracy Group
 Andrea COZZOLINO,https://twitter.com/cozzolino62,@cozzolino62,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -205,10 +205,10 @@ Elżbieta Katarzyna ŁUKACIJEWSKA,https://twitter.com/elukacijewska,@elukacijews
 Elżbieta KRUK,,,Poland,European Conservatives and Reformists Group
 Elżbieta RAFALSKA,https://twitter.com/e_rafalska,@e_rafalska,Poland,European Conservatives and Reformists Group
 Emil RADEV,https://twitter.com/emil_radev,@emil_radev,Bulgaria,Group of the European People's Party (Christian Democrats)
-Emmanouil FRAGKOS,https://twitter.com/manolis_fragkos ,@manolis_fragkos,Greece,European Conservatives and Reformists Group
+Emmanouil FRAGKOS,,,Greece,European Conservatives and Reformists Group
 Emmanuel MAUREL,https://twitter.com/emmanuelmaurel,@emmanuelmaurel,France,Confederal Group of the European United Left - Nordic Green Left
 Engin EROGLU,https://twitter.com/EnginEroglu_FW,@EnginEroglu_FW,Germany,Renew Europe Group
-Enikő GYŐRI,https://twitter.com/EGyori,@EGyori,Hungary,Group of the European People's Party (Christian Democrats)
+Enikő GYŐRI,https://twitter.com/GyoriEniko,@GyoriEniko,Hungary,Group of the European People's Party (Christian Democrats)
 Eric ANDRIEU,https://twitter.com/EricAndrieuEU,@EricAndrieuEU,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Erik BERGKVIST,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Erik MARQUARDT,https://twitter.com/erikmarquardt,@erikmarquardt,Germany,Group of the Greens/European Free Alliance
@@ -405,7 +405,7 @@ Kris PEETERS,https://twitter.com/peeters_kris1 ,@peeters_kris1 ,Belgium,Group of
 Krzysztof HETMAN,https://twitter.com/hetman_k,@hetman_k,Poland,Group of the European People's Party (Christian Democrats)
 Krzysztof JURGIEL,,,Poland,European Conservatives and Reformists Group
 Lance FORMAN,https://twitter.com/LanceForman ,@LanceForman ,United Kingdom,Non-attached Members
-Lara WOLTERS,https://twitter.com/wolters_lara ,@wolters_lara,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament 
+Lara WOLTERS,https://twitter.com/larawoltersEU,@larawoltersEU,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament 
 Lars Patrick BERG,https://www.twitter.com/larspatrickberg,@larspatrickberg,Germany,Identity and Democracy Group
 László TRÓCSÁNYI,https://twitter.com/trocsanyi ,@trocsanyi ,Hungary,Group of the European People's Party (Christian Democrats)
 Laura FERRARA,https://twitter.com/LFerraraM5S,@LFerraraM5S,Italy,Non-attached Members
@@ -507,7 +507,7 @@ Maximilian KRAH,https://twitter.com/krahmax,@krahmax,Germany,Identity and Democr
 Mazaly AGUILAR,https://twitter.com/MazalyAguilar ,@MazalyAguilar ,Spain,European Conservatives and Reformists Group
 Miapetra KUMPULA-NATRI,https://twitter.com/miapetrakumpula,@miapetrakumpula,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Michael BLOSS,https://twitter.com/michabl,@michabl,Germany,Group of the Greens/European Free Alliance
-Michael GAHLER,https://twitter.com/michaelgahler ,@michaelgahler ,Germany,Group of the European People's Party (Christian Democrats)
+Michael GAHLER,https://twitter.com/michaelgahler,@michaelgahler ,Germany,Group of the European People's Party (Christian Democrats)
 Michael HEAVER,https://twitter.com/michael_heaver,@michael_heaver,United Kingdom,Non-attached Members
 Michaela ŠOJDROVÁ,https://twitter.com/msojdrova ,@msojdrova ,Czechia,Group of the European People's Party (Christian Democrats)
 Michal ŠIMEČKA,,,Slovakia,Renew Europe Group

--- a/meps_full_list_with_twitter_accounts.csv
+++ b/meps_full_list_with_twitter_accounts.csv
@@ -1,10 +1,10 @@
 NAME,TWITTER_URL,SCREEN_NAME,NATIONALITY,GROUP
-Abir AL SAHLANI,https://twitter.com/abiralsahlani,@abiralsahlani,Sweden,Renew Europe Group
+Abir AL-SAHLANI,https://twitter.com/abiralsahlani,@abiralsahlani,Sweden,Renew Europe Group
 Adam BIELAN,https://twitter.com/AdamBielan,@AdamBielan,Poland,European Conservatives and Reformists Group
 Adam JARUBAS,https://twitter.com/JarubasAdam,@JarubasAdam,Poland,Group of the European People's Party (Christian Democrats)
 Ádám KÓSA,https://twitter.com/adamkosamep,@adamkosamep,Hungary,Group of the European People's Party (Christian Democrats)
 Adina-Ioana VĂLEAN,https://twitter.com/AdinaValean,@AdinaValean,Romania,Group of the European People's Party (Christian Democrats)
-Adrian-Dragoș BENEA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Adrian-Dragoş BENEA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Adriana MALDONADO LÓPEZ,https://twitter.com/_AMaldonado_,@_AMaldonado_,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Agnès EVREN,https://twitter.com/agnesevren,@agnesevren,France,Group of the European People's Party (Christian Democrats)
 Agnes JONGERIUS,https://twitter.com/a_jongerius,@a_jongerius,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -20,7 +20,7 @@ Alexandr VONDRA,https://twitter.com/alexandrvondra,@alexandrvondra,Czechia,Europ
 Alexandra GEESE,https://twitter.com/alexandra_geese,@alexandra_geese,Germany,Group of the Greens/European Free Alliance
 Alexandra Lesley PHILLIPS,https://twitter.com/brexitalex,@brexitalex,United Kingdom,Non-attached Members
 Alexandra Louise Rosenfield PHILLIPS,https://twitter.com/alexforeurope,@alexforeurope,United Kingdom,Group of the Greens/European Free Alliance
-Alexandros GEORGOULIS,https://twitter.com/AlexisMep,@AlexisMep,Greece,Confederal Group of the European United Left - Nordic Green Left
+Alexis GEORGOULIS,https://twitter.com/AlexisMep,@AlexisMep,Greece,Confederal Group of the European United Left - Nordic Green Left
 Alfred SANT,https://twitter.com/SantAlfred,@SantAlfred,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Alice KUHNKE,,,Sweden,Group of the Greens/European Free Alliance
 Alicia HOMS GINEL,https://twitter.com/aliciahoms,@aliciahoms,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -54,7 +54,7 @@ Anna BONFRISCO,,,Italy,Identity and Democracy Group
 Anna CAVAZZINI,https://twitter.com/anna_cavazzini,@anna_cavazzini,Germany,Group of the Greens/European Free Alliance
 Anna DEPARNAY-GRUNENBERG,https://twitter.com/AnnaDeparnay,@AnnaDeparnay,Germany,Group of the Greens/European Free Alliance
 Anna FOTYGA,https://twitter.com/AnnaFotyga_PE,@AnnaFotyga_PE,Poland,European Conservatives and Reformists Group
-Anna Julia DONÁTH,https://twitter.com/donath_anna,@donath_anna,Hungary,Renew Europe Group
+Anna Júlia DONÁTH,https://twitter.com/donath_anna,@donath_anna,Hungary,Renew Europe Group
 Anna ZALEWSKA,https://twitter.com/_AnnaZalewska,@_AnnaZalewska,Poland,European Conservatives and Reformists Group
 Anna-Michelle ASIMAKOPOULOU,https://twitter.com/AnnaAsimakopoul,@AnnaAsimakopoul,Greece,Group of the European People's Party (Christian Democrats)
 Annalisa TARDINO,https://twitter.com/tardinoannalisa,@tardinoannalisa,Italy,Identity and Democracy Group
@@ -128,7 +128,7 @@ Chris DAVIES,https://twitter.com/ChrisDaviesEU,@ChrisDaviesEU,United Kingdom,Ren
 Christel SCHALDEMOSE,https://twitter.com/SchaldemoseMEP,@SchaldemoseMEP,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Christian ALLARD,https://twitter.com/christia_allard,@christia_allard,United Kingdom,Group of the Greens/European Free Alliance
 Christian EHLER,,,Germany,Group of the European People's Party (Christian Democrats)
-Christian Konrad DOLESCHAL,https://twitter.com/Doleschal,@Doleschal,Germany,Group of the European People's Party (Christian Democrats)
+Christian DOLESCHAL,https://twitter.com/Doleschal,@Doleschal,Germany,Group of the European People's Party (Christian Democrats)
 Christina Sheila JORDAN,https://twitter.com/CJordanjb,@CJordanjb,United Kingdom,Non-attached Members
 Christine ANDERSON,,,Germany,Identity and Democracy Group
 Christine SCHNEIDER,https://twitter.com/ChSchneider,@ChSchneider,Germany,Group of the European People's Party (Christian Democrats)
@@ -150,16 +150,16 @@ Corina CREȚU,https://twitter.com/CorinaCretuEU,@CorinaCretuEU,Romania,Group of 
 Cornelia ERNST,https://twitter.com/ErnstCornelia,@ErnstCornelia,Germany,Confederal Group of the European United Left - Nordic Green Left
 Costas MAVRIDES,https://twitter.com/MavridesCostas,@MavridesCostas,Cyprus,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Cristian GHINEA,https://twitter.com/GhineaMEP,@GhineaMEP,Romania,Renew Europe Group
-Cristian TERHEȘ,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Cristian TERHEŞ,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Cristian-Silviu BUŞOI,,,Romania,Group of the European People's Party (Christian Democrats)
 Cristina MAESTRE MARTÍN DE ALMAGRO,https://twitter.com/crismaestre,@crismaestre,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Csaba MOLNÁR,,,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Dace MELBĀRDE,,,Latvia,European Conservatives and Reformists Group
-Dacian CIOLOS,https://twitter.com/CiolosDacian,@CiolosDacian,Romania,Renew Europe Group
+Dacian CIOLOŞ,https://twitter.com/CiolosDacian,@CiolosDacian,Romania,Renew Europe Group
 Damian BOESELAGER,https://twitter.com/d_boeselager,@d_boeselager,Germany,Group of the Greens/European Free Alliance
 Damien CARÊME,https://twitter.com/damiencareme,@damiencareme,France,Group of the Greens/European Free Alliance
 Dan NICA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Dan-Ștefan MOTREANU,https://twitter.com/Dan_Motreanu,@Dan_Motreanu,Romania,Group of the European People's Party (Christian Democrats)
+Dan-Ştefan MOTREANU,https://twitter.com/Dan_Motreanu,@Dan_Motreanu,Romania,Group of the European People's Party (Christian Democrats)
 Daniel BUDA,https://twitter.com/MEPDanielBuda,@MEPDanielBuda,Romania,Group of the European People's Party (Christian Democrats)
 Daniel CASPARY,https://twitter.com/caspary,@caspary,Germany,Group of the European People's Party (Christian Democrats)
 Daniel FREUND,https://twitter.com/daniel_freund,@daniel_freund,Germany,Group of the Greens/European Free Alliance
@@ -171,7 +171,7 @@ David CASA,https://twitter.com/DavidCasaMEP,@DavidCasaMEP,Malta,Group of the Eur
 David CORMAND,https://twitter.com/DavidCormand,@DavidCormand,France,Group of the Greens/European Free Alliance
 David LEGA,https://twitter.com/davidlega,@davidlega,Sweden,Group of the European People's Party (Christian Democrats)
 David McALLISTER,https://twitter.com/davidmcallister,@davidmcallister,Germany,Group of the European People's Party (Christian Democrats)
-David-Maria SASSOLI,https://twitter.com/DavidSassoli,@DavidSassoli,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+David Maria SASSOLI,https://twitter.com/DavidSassoli,@DavidSassoli,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Delara BURKHARDT,https://twitter.com/delarabur,@delarabur,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Demetris PAPADAKIS,https://twitter.com/DemPapadakis,@DemPapadakis,Cyprus,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Dennis RADTKE,https://twitter.com/RadtkeMdEP,@RadtkeMdEP,Germany,Group of the European People's Party (Christian Democrats)
@@ -187,8 +187,8 @@ Dolors MONTSERRAT,https://twitter.com/dolorsmm,@dolorsmm,Spain,Group of the Euro
 Domènec RUIZ DEVESA,https://twitter.com/domenecd,@domenecd,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Dominique BILDE,https://twitter.com/dominiquebilde,@dominiquebilde,France,Identity and Democracy Group
 Dominique RIQUET,https://twitter.com/DominiqueRiquet,@DominiqueRiquet,France,Renew Europe Group
-Dragoș PÎSLARU,https://twitter.com/dragos_pislaru,@dragos_pislaru,Romania,Renew Europe Group
-Dragoș TUDORACHE,https://twitter.com/IoanDragosT,@IoanDragosT,Romania,Renew Europe Group
+Dragoş PÎSLARU,https://twitter.com/dragos_pislaru,@dragos_pislaru,Romania,Renew Europe Group
+Dragoş TUDORACHE,https://twitter.com/IoanDragosT,@IoanDragosT,Romania,Renew Europe Group
 Dubravka ŠUICA,https://twitter.com/dubravkasuica,@dubravkasuica,Croatia,Group of the European People's Party (Christian Democrats)
 Edina TÓTH,https://twitter.com/toth_edina,@toth_edina,Hungary,Group of the European People's Party (Christian Democrats)
 Eero HEINÄLUOMA,https://twitter.com/EeroHeinaluoma,@EeroHeinaluoma,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -215,7 +215,7 @@ Erik MARQUARDT,https://twitter.com/erikmarquardt,@erikmarquardt,Germany,Group of
 Ernest URTASUN,https://twitter.com/ernesturtasun,@ernesturtasun,Spain,Group of the Greens/European Free Alliance
 Esteban GONZÁLEZ PONS,https://twitter.com/gonzalezpons,@gonzalezpons,Spain,Group of the European People's Party (Christian Democrats)
 Esther de LANGE,https://twitter.com/Esther_de_Lange,@Esther_de_Lange,Netherlands,Group of the European People's Party (Christian Democrats)
-Estrella DURA FERRANDIS,,,Spain,Non-attached Members
+Estrella DURÁ FERRANDIS,,,Spain,Non-attached Members
 Eugen JURZYCA,https://twitter.com/EugenJurzyca,@EugenJurzyca,Slovakia,European Conservatives and Reformists Group
 Eugen TOMAC,https://twitter.com/eugen_tomac,@eugen_tomac,Romania,Group of the European People's Party (Christian Democrats)
 Eugenia RODRÍGUEZ PALOP,https://twitter.com/MEugeniaRPalop,@MEugeniaRPalop,Spain,Confederal Group of the European United Left - Nordic Green Left
@@ -262,7 +262,7 @@ Giuseppe MILAZZO,https://twitter.com/giuseppemilaz11,@giuseppemilaz11,Italy,Grou
 Grace O'SULLIVAN,https://twitter.com/GraceOSllvn,@GraceOSllvn,Ireland,Group of the Greens/European Free Alliance
 Grzegorz TOBISZOWSKI,https://twitter.com/tobiszowski,@tobiszowski,Poland,European Conservatives and Reformists Group
 Guido REIL,https://twitter.com/GuidoReil,@GuidoReil,Germany,Identity and Democracy Group
-Gunnar Günter BECK,,,Germany,Identity and Democracy Group
+Gunnar BECK,,,Germany,Identity and Democracy Group
 Günther SIDL,,,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Guy VERHOFSTADT,https://twitter.com/GuyVerhofstadt,@GuyVerhofstadt,Belgium,Renew Europe Group
 Gwendoline DELBOS-CORFIELD,https://twitter.com/GDelbosCorfield,@GDelbosCorfield,France,Group of the Greens/European Free Alliance
@@ -277,20 +277,20 @@ Helmut GEUKING,,,Germany,European Conservatives and Reformists Group
 Helmut SCHOLZ,https://twitter.com/HelmutScholzMEP,@HelmutScholzMEP,Germany,Confederal Group of the European United Left - Nordic Green Left
 Henna VIRKKUNEN,https://twitter.com/HennaVirkkunen,@HennaVirkkunen,Finland,Group of the European People's Party (Christian Democrats)
 Henrik OVERGAARD NIELSEN,https://twitter.com/brexithenrik,@brexithenrik,United Kingdom,Non-attached Members
-Henrike Nanna Gisela HAHN,https://twitter.com/henrikehahn,@henrikehahn,Germany,Group of the Greens/European Free Alliance
+Henrike HAHN,https://twitter.com/henrikehahn,@henrikehahn,Germany,Group of the Greens/European Free Alliance
 Herbert DORFMANN,https://twitter.com/HerbertDorfmann,@HerbertDorfmann,Italy,Group of the European People's Party (Christian Democrats)
 Hermann TERTSCH,https://twitter.com/hermanntertsch,@hermanntertsch,Spain,European Conservatives and Reformists Group
 Herve JUVIN,https://twitter.com/HerveJuvin,@HerveJuvin,France,Identity and Democracy Group
 Hilde VAUTMANS,https://twitter.com/hildevautmans,@hildevautmans,Belgium,Renew Europe Group
 Hildegard BENTELE,https://twitter.com/hildebentele,@hildebentele,Germany,Group of the European People's Party (Christian Democrats)
 Hynek BLAŠKO,,,Czechia,Identity and Democracy Group
-Ibán GARCIA DEL BLANCO,https://twitter.com/Ibangarciadb,@Ibangarciadb,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Ibán GARCÍA DEL BLANCO,https://twitter.com/Ibangarciadb,@Ibangarciadb,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Idoia VILLANUEVA RUIZ,https://twitter.com/idoiavr,@idoiavr,Spain,Confederal Group of the European United Left - Nordic Green Left
 Ignazio CORRAO,https://twitter.com/ignaziocorrao,@ignaziocorrao,Italy,Non-attached Members
 Ilhan KYUCHYUK,https://twitter.com/ilhankyuchyuk,@ilhankyuchyuk,Bulgaria,Renew Europe Group
 Inese VAIDERE,https://twitter.com/inesevaidere,@inesevaidere,Latvia,Group of the European People's Party (Christian Democrats)
 Inma RODRÍGUEZ-PIÑERO,https://twitter.com/RodriguezPinero,@RodriguezPinero,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Ioan-Rareș BOGDAN,,,Romania,Group of the European People's Party (Christian Democrats)
+Ioan-Rareş BOGDAN,,,Romania,Group of the European People's Party (Christian Democrats)
 Ioannis LAGOS,,,Greece,Non-attached Members
 Iratxe GARCÍA PÉREZ,https://twitter.com/IratxeGarper,@IratxeGarper,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Irena JOVEVA,https://twitter.com/ijoveva,@ijoveva,Slovenia,Renew Europe Group
@@ -298,6 +298,7 @@ Irene TINAGLI,https://twitter.com/itinagli,@itinagli,Italy,Group of the Progress
 Irène TOLLERET,https://twitter.com/ITolleret,@ITolleret,France,Renew Europe Group
 Irina VON WIESE,https://twitter.com/irinavonwiese,@irinavonwiese,United Kingdom,Renew Europe Group
 Isabel BENJUMEA BENJUMEA,https://twitter.com/IsabelBenjumea,@IsabelBenjumea,Spain,Group of the European People's Party (Christian Democrats)
+Isabel CARVALHAIS,,,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Isabel GARCÍA MUÑOZ,,,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Isabel SANTOS,https://twitter.com/isabel_mep,@isabel_mep,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Isabel WISELER-LIMA,https://twitter.com/iwiseler,@iwiseler,Luxembourg,Group of the European People's Party (Christian Democrats)
@@ -419,11 +420,11 @@ Leopoldo LÓPEZ GIL,,,Spain,Group of the European People's Party (Christian Demo
 Leszek MILLER,https://twitter.com/LeszekMiller,@LeszekMiller,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Lídia PEREIRA,https://twitter.com/lidiafopereira,@lidiafopereira,Portugal,Group of the European People's Party (Christian Democrats)
 Liesje SCHREINEMACHER,https://twitter.com/LSchreinemacher,@LSchreinemacher,Netherlands,Renew Europe Group
-Lina GALVEZ MUÑOZ,https://twitter.com/linagalvezmunoz,@linagalvezmunoz,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Lina GÁLVEZ MUÑOZ,https://twitter.com/linagalvezmunoz,@linagalvezmunoz,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Liudas MAŽYLIS,,,Lithuania,Group of the European People's Party (Christian Democrats)
 Lívia JÁRÓKA,https://twitter.com/JarokaLivia,@JarokaLivia,Hungary,Group of the European People's Party (Christian Democrats)
 Ljudmila NOVAK,https://twitter.com/LjudmilaNovak,@LjudmilaNovak,Slovenia,Group of the European People's Party (Christian Democrats)
-Lorant-Gyorgy VINCZE,https://twitter.com/vinczelorant,@vinczelorant,Romania,Group of the European People's Party (Christian Democrats)
+Loránt VINCZE,https://twitter.com/vinczelorant,@vinczelorant,Romania,Group of the European People's Party (Christian Democrats)
 Loucas FOURLAS,https://twitter.com/loucas_fourlas,@loucas_fourlas,Cyprus,Group of the European People's Party (Christian Democrats)
 Louis STEDMAN-BRYCE,https://twitter.com/lstedmanbryce,@lstedmanbryce,United Kingdom,Non-attached Members
 Lucia ĎURIŠ NICHOLSONOVÁ,https://twitter.com/LNicholsonova,@LNicholsonova,Slovakia,European Conservatives and Reformists Group
@@ -446,7 +447,7 @@ Malin BJÖRK,https://twitter.com/MalinBjork_EU,@MalinBjork_EU,Sweden,Confederal 
 Manfred WEBER,https://twitter.com/ManfredWeber,@ManfredWeber,Germany,Group of the European People's Party (Christian Democrats)
 Manolis KEFALOGIANNIS,https://twitter.com/M_Kefalogiannis,@M_Kefalogiannis,Greece,Group of the European People's Party (Christian Democrats)
 Manon AUBRY,https://twitter.com/manonaubryfr,@manonaubryfr,France,Confederal Group of the European United Left - Nordic Green Left
-Manu PINEDA MARÍN,https://twitter.com/manu_abu_carlos,@manu_abu_carlos,Spain,Confederal Group of the European United Left - Nordic Green Left
+Manu PINEDA,https://twitter.com/manu_abu_carlos,@manu_abu_carlos,Spain,Confederal Group of the European United Left - Nordic Green Left
 Manuel BOMPARD,https://twitter.com/mbompard,@mbompard,France,Confederal Group of the European United Left - Nordic Green Left
 Manuel PIZARRO,https://twitter.com/MPizarroPorto,@MPizarroPorto,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Mara BIZZOTTO,https://twitter.com/marabizzotto,@marabizzotto,Italy,Identity and Democracy Group
@@ -548,9 +549,9 @@ Nico SEMSROTT,https://www.twitter.com/nicosemsrott,@nicosemsrott,Germany,Group o
 Nicola BEER,https://twitter.com/nicolabeerfdp,@nicolabeerfdp,Germany,Renew Europe Group
 Nicola DANTI,https://twitter.com/DantiNicola,@DantiNicola,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nicola PROCACCINI,https://twitter.com/nprocaccini,@Nprocaccini,Italy,European Conservatives and Reformists Group
-Nicolae ȘTEFĂNUȚA,https://twitter.com/nicustefanuta,@nicustefanuta,Romania,Renew Europe Group
+Nicolae ŞTEFĂNUȚĂ,https://twitter.com/nicustefanuta,@nicustefanuta,Romania,Renew Europe Group
 Nicolas BAY,https://twitter.com/NicolasBay_,@NicolasBay_,France,Identity and Democracy Group
-Nicolás GONZALEZ CASARES,https://twitter.com/nicogoncas,@nicogoncas,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Nicolás GONZÁLEZ CASARES,https://twitter.com/nicogoncas,@nicogoncas,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nicolas SCHMIT,https://twitter.com/nicolasschmit2,@nicolasschmit2,Luxembourg,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nicolaus FEST,https://twitter.com/Nicolaus_Fest,@Nicolaus_Fest,Germany,Identity and Democracy Group
 Niels FUGLSANG,https://twitter.com/NielsFuglsang,@NielsFuglsang,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -563,12 +564,12 @@ Nils UŠAKOVS,https://twitter.com/nilsusakovs,@nilsusakovs,Latvia,Group of the P
 Niyazi KIZILYÜREK,https://twitter.com/NKizilyurek,@NKizilyurek,Cyprus,Confederal Group of the European United Left - Nordic Green Left
 Norbert LINS,,,Germany,Group of the European People's Party (Christian Democrats)
 Norbert NEUSER,,,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Nosheena MOBARIK Baroness,https://twitter.com/NosheenaMobarik,@NosheenaMobarik,United Kingdom,European Conservatives and Reformists Group
+Baroness Nosheena MOBARIK,https://twitter.com/NosheenaMobarik,@NosheenaMobarik,United Kingdom,European Conservatives and Reformists Group
 Nuno MELO,https://twitter.com/NunoMeloCDS,@NunoMeloCDS,Portugal,Group of the European People's Party (Christian Democrats)
 Olivier CHASTEL,https://twitter.com/OChastel,@OChastel,Belgium,Renew Europe Group
 Ondřej KNOTEK,https://twitter.com/KnotekOndrej,@KnotekOndrej,Czechia,Renew Europe Group
 Ondřej KOVAŘÍK,https://twitter.com/OKovarikMEP,@OkovarikMEP,Czechia,Renew Europe Group
-Oscar LANCINI,https://twitter.com/doscarlancini,@doscarlancini,Italy,Identity and Democracy Group
+Danilo Oscar LANCINI,https://twitter.com/doscarlancini,@doscarlancini,Italy,Identity and Democracy Group
 Othmar KARAS,https://twitter.com/othmar_karas,@othmar_karas,Austria,Group of the European People's Party (Christian Democrats)
 Özlem DEMIREL,https://twitter.com/oezlemademirel,@oezlemademirel,Germany,Confederal Group of the European United Left - Nordic Green Left
 Pablo ARIAS ECHEVERRÍA,,,Spain,Group of the European People's Party (Christian Democrats)
@@ -589,6 +590,7 @@ Pernando BARRENA ARZA,https://twitter.com/pernandobarrena,@pernandobarrena,Spain
 Pernille WEISS,https://twitter.com/WeissPernille,@WeissPernille,Denmark,Group of the European People's Party (Christian Democrats)
 Petar VITANOV,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Peter JAHR,https://twitter.com/peter_jahr,@peter_jahr,Germany,Group of the European People's Party (Christian Democrats)
+Peter KOFOD,https://twitter.com/KofodPeter,@KofodPeter,Denmark,Identity and Democracy Group
 Peter LIESE,https://twitter.com/peterliese,@peterliese,Germany,Group of the European People's Party (Christian Democrats)
 Peter LUNDGREN,,,Sweden,European Conservatives and Reformists Group
 Peter POLLÁK,https://twitter.com/Peter_Pollak,@Peter_Pollak,Slovakia,Group of the European People's Party (Christian Democrats)
@@ -605,7 +607,7 @@ Pierfrancesco MAJORINO,https://twitter.com/pfmajorino,@pfmajorino,Italy,Group of
 Piernicola PEDICINI,https://twitter.com/PediciniM5S,@PediciniM5S,Italy,Non-attached Members
 Pierre KARLESKIND,https://twitter.com/Pierre_Ka,@Pierre_Ka,France,Renew Europe Group
 Pierre LARROUTUROU,https://twitter.com/larrouturou,@larrouturou,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Pierrette Gabrielle HERZBERGER-FOFANA,,,Germany,Group of the Greens/European Free Alliance
+Pierrette HERZBERGER-FOFANA,,,Germany,Group of the Greens/European Free Alliance
 Pietro BARTOLO,https://twitter.com/bartolopietro1,@bartolopietro1,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pietro FIOCCHI,https://twitter.com/FiocchiPietro,@FiocchiPietro,Italy,European Conservatives and Reformists Group
 Pilar del CASTILLO VERA,https://twitter.com/delcastillop,@delcastillop,Spain,Group of the European People's Party (Christian Democrats)
@@ -624,7 +626,7 @@ Rasa JUKNEVIČIENĖ,https://twitter.com/rjukneviciene,@rjukneviciene,Lithuania,G
 Rasmus ANDRESEN,https://twitter.com/RasmusAndresen,@RasmusAndresen,Germany,Group of the Greens/European Free Alliance
 Reinhard BÜTIKOFER,https://twitter.com/bueti,@bueti,Germany,Group of the Greens/European Free Alliance
 Richard CORBETT,https://twitter.com/RCorbettMEP,@RCorbettMEP,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Richard James TICE,https://twitter.com/TiceRichard,@TiceRichard,United Kingdom,Non-attached Members
+Richard TICE,https://twitter.com/TiceRichard,@TiceRichard,United Kingdom,Non-attached Members
 Rob ROOKEN,https://twitter.com/rooken,@rooken,Netherlands,European Conservatives and Reformists Group
 Robert BIEDROŃ,https://twitter.com/robertbiedron,@robertbiedron,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Robert HAJŠEL,https://twitter.com/RobertHajsel,@RobertHajsel,Slovakia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -674,7 +676,7 @@ Sira REGO,https://twitter.com/SIRAREGO,@SIRAREGO,Spain,Confederal Group of the E
 Sirpa PIETIKÄINEN,https://twitter.com/spietikainen,@spietikainen,Finland,Group of the European People's Party (Christian Democrats)
 Ska KELLER,https://twitter.com/SkaKeller,@SkaKeller,Germany,Group of the Greens/European Free Alliance
 Sophia in 't VELD,https://twitter.com/SophieintVeld,@SophieintVeld,Netherlands,Renew Europe Group
-Søren Gade GADE,https://twitter.com/SoerenGade,@SoerenGade,Denmark,Renew Europe Group
+Søren GADE,https://twitter.com/SoerenGade,@SoerenGade,Denmark,Renew Europe Group
 Stanislav POLČÁK,https://twitter.com/stanislavpolcak,@stanislavpolcak,Czechia,Group of the European People's Party (Christian Democrats)
 Stasys JAKELIŪNAS,,,Lithuania,Group of the Greens/European Free Alliance
 Stefan BERGER,https://twitter.com/DrStefanBerger,@DrStefanBerger,Germany,Group of the European People's Party (Christian Democrats)
@@ -735,7 +737,7 @@ Vilija BLINKEVIČIŪTĖ,,,Lithuania,Group of the Progressive Alliance of Sociali
 Ville NIINISTÖ,https://www.twitter.com/villeniinisto,@villeniinisto,Finland,Group of the Greens/European Free Alliance
 Viola VON CRAMON-TAUBADEL,https://twitter.com/violavoncramon,@violavoncramon,Germany,Group of the Greens/European Free Alliance
 Virginie JORON,https://twitter.com/v_joron,@v_joron,France,Identity and Democracy Group
-Vlad-Marius BOTOȘ,,,Romania,Renew Europe Group
+Vlad-Marius BOTOŞ,,,Romania,Renew Europe Group
 Vladimír BILČÍK,https://twitter.com/vladobilcik,@vladobilcik,Slovakia,Group of the European People's Party (Christian Democrats)
 Witold Jan WASZCZYKOWSKI,https://twitter.com/WaszczykowskiW,@WaszczykowskiW,Poland,European Conservatives and Reformists Group
 Włodzimierz CIMOSZEWICZ,,,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament

--- a/meps_full_list_with_twitter_accounts.csv
+++ b/meps_full_list_with_twitter_accounts.csv
@@ -189,7 +189,7 @@ Dominique BILDE,https://twitter.com/dominiquebilde,@dominiquebilde,France,Identi
 Dominique RIQUET,https://twitter.com/DominiqueRiquet,@DominiqueRiquet,France,Renew Europe Group
 Dragoș PÎSLARU,https://twitter.com/dragos_pislaru,@dragos_pislaru,Romania,Renew Europe Group
 Dragoș TUDORACHE,https://twitter.com/IoanDragosT,@IoanDragosT,Romania,Renew Europe Group
-Dubravka ŠUICA,https://twitter.com/dubravkasuica ,@dubravkasuica ,Croatia,Group of the European People's Party (Christian Democrats)
+Dubravka ŠUICA,https://twitter.com/dubravkasuica,@dubravkasuica,Croatia,Group of the European People's Party (Christian Democrats)
 Edina TÓTH,https://twitter.com/toth_edina,@toth_edina,Hungary,Group of the European People's Party (Christian Democrats)
 Eero HEINÄLUOMA,https://twitter.com/EeroHeinaluoma,@EeroHeinaluoma,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Eider GARDIAZABAL RUBIAL,https://twitter.com/EGardiazabal,@EGardiazabal,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -260,27 +260,27 @@ Giuliano PISAPIA,https://twitter.com/giulianopisapia,@giulianopisapia,Italy,Grou
 Giuseppe FERRANDINO,https://twitter.com/giosiferrandino,@giosiferrandino,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Giuseppe MILAZZO,https://twitter.com/giuseppemilaz11,@giuseppemilaz11,Italy,Group of the European People's Party (Christian Democrats)
 Grace O'SULLIVAN,https://twitter.com/GraceOSllvn,@GraceOSllvn,Ireland,Group of the Greens/European Free Alliance
-Grzegorz TOBISZOWSKI,https://twitter.com/tobiszowski ,@tobiszowski ,Poland,European Conservatives and Reformists Group
-Guido REIL,https://twitter.com/GuidoReil ,@GuidoReil ,Germany,Identity and Democracy Group
+Grzegorz TOBISZOWSKI,https://twitter.com/tobiszowski,@tobiszowski,Poland,European Conservatives and Reformists Group
+Guido REIL,https://twitter.com/GuidoReil,@GuidoReil,Germany,Identity and Democracy Group
 Gunnar Günter BECK,,,Germany,Identity and Democracy Group
 Günther SIDL,,,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Guy VERHOFSTADT,https://twitter.com/GuyVerhofstadt,@GuyVerhofstadt,Belgium,Renew Europe Group
-Gwendoline DELBOS-CORFIELD,https://twitter.com/GDelbosCorfield ,@GDelbosCorfield ,France,Group of the Greens/European Free Alliance
+Gwendoline DELBOS-CORFIELD,https://twitter.com/GDelbosCorfield,@GDelbosCorfield,France,Group of the Greens/European Free Alliance
 György HÖLVÉNYI,https://twitter.com/HolvenyiGyorgy,@HolvenyiGyorgy,Hungary,Group of the European People's Party (Christian Democrats)
 Hannah NEUMANN,https://twitter.com/Hannah_LBerg,@Hannah_LBerg,Germany,Group of the Greens/European Free Alliance
 Hannes HEIDE,https://twitter.com/HannesHeide,@HannesHeide,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Harald VILIMSKY,https://twitter.com/vilimsky ,@vilimsky ,Austria,Identity and Democracy Group
-Heidi HAUTALA,https://twitter.com/HeidiHautala ,@HeidiHautala ,Finland,Group of the Greens/European Free Alliance
+Harald VILIMSKY,https://twitter.com/vilimsky,@vilimsky,Austria,Identity and Democracy Group
+Heidi HAUTALA,https://twitter.com/HeidiHautala,@HeidiHautala,Finland,Group of the Greens/European Free Alliance
 Heléne FRITZON,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Hélène LAPORTE,https://twitter.com/HeleneLaporteRN,@HeleneLaporteRN,France,Identity and Democracy Group
 Helmut GEUKING,,,Germany,European Conservatives and Reformists Group
-Helmut SCHOLZ,https://twitter.com/HelmutScholzMEP ,@HelmutScholzMEP ,Germany,Confederal Group of the European United Left - Nordic Green Left
+Helmut SCHOLZ,https://twitter.com/HelmutScholzMEP,@HelmutScholzMEP,Germany,Confederal Group of the European United Left - Nordic Green Left
 Henna VIRKKUNEN,https://twitter.com/HennaVirkkunen,@HennaVirkkunen,Finland,Group of the European People's Party (Christian Democrats)
 Henrik OVERGAARD NIELSEN,https://twitter.com/brexithenrik,@brexithenrik,United Kingdom,Non-attached Members
 Henrike Nanna Gisela HAHN,https://twitter.com/henrikehahn,@henrikehahn,Germany,Group of the Greens/European Free Alliance
-Herbert DORFMANN,https://twitter.com/HerbertDorfmann ,@HerbertDorfmann ,Italy,Group of the European People's Party (Christian Democrats)
+Herbert DORFMANN,https://twitter.com/HerbertDorfmann,@HerbertDorfmann,Italy,Group of the European People's Party (Christian Democrats)
 Hermann TERTSCH,https://twitter.com/hermanntertsch,@hermanntertsch,Spain,European Conservatives and Reformists Group
-Herve JUVIN,https://twitter.com/HerveJuvin ,@HerveJuvin ,France,Identity and Democracy Group
+Herve JUVIN,https://twitter.com/HerveJuvin,@HerveJuvin,France,Identity and Democracy Group
 Hilde VAUTMANS,https://twitter.com/hildevautmans,@hildevautmans,Belgium,Renew Europe Group
 Hildegard BENTELE,https://twitter.com/hildebentele,@hildebentele,Germany,Group of the European People's Party (Christian Democrats)
 Hynek BLAŠKO,,,Czechia,Identity and Democracy Group
@@ -295,30 +295,30 @@ Ioannis LAGOS,,,Greece,Non-attached Members
 Iratxe GARCÍA PÉREZ,https://twitter.com/IratxeGarper,@IratxeGarper,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Irena JOVEVA,https://twitter.com/ijoveva,@ijoveva,Slovenia,Renew Europe Group
 Irene TINAGLI,https://twitter.com/itinagli,@itinagli,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Irène TOLLERET,https://twitter.com/ITolleret ,@ITolleret ,France,Renew Europe Group
+Irène TOLLERET,https://twitter.com/ITolleret,@ITolleret,France,Renew Europe Group
 Irina VON WIESE,https://twitter.com/irinavonwiese,@irinavonwiese,United Kingdom,Renew Europe Group
-Isabel BENJUMEA BENJUMEA,https://twitter.com/IsabelBenjumea ,@IsabelBenjumea ,Spain,Group of the European People's Party (Christian Democrats)
+Isabel BENJUMEA BENJUMEA,https://twitter.com/IsabelBenjumea,@IsabelBenjumea,Spain,Group of the European People's Party (Christian Democrats)
 Isabel GARCÍA MUÑOZ,,,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Isabel SANTOS,https://twitter.com/isabel_mep ,@isabel_mep ,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Isabel SANTOS,https://twitter.com/isabel_mep,@isabel_mep,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Isabel WISELER-LIMA,https://twitter.com/iwiseler,@iwiseler,Luxembourg,Group of the European People's Party (Christian Democrats)
 Isabella ADINOLFI,https://twitter.com/Isa_Adinolfi,@Isa_Adinolfi,Italy,Non-attached Members
-Isabella TOVAGLIERI,https://twitter.com/isatovaglieri ,@isatovaglieri ,Italy,Identity and Democracy Group
-Iskra MIHAYLOVA,https://twitter.com/Iskra_Mihaylova ,@Iskra_Mihaylova ,Bulgaria,Renew Europe Group
+Isabella TOVAGLIERI,https://twitter.com/isatovaglieri,@isatovaglieri,Italy,Identity and Democracy Group
+Iskra MIHAYLOVA,https://twitter.com/Iskra_Mihaylova,@Iskra_Mihaylova,Bulgaria,Renew Europe Group
 Ismail ERTUG,https://twitter.com/IsmailErtug,@IsmailErtug,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 István UJHELYI,https://twitter.com/istvan_ujhelyi,@istvan_ujhelyi,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Iuliu WINKLER,https://twitter.com/IuliuWinkler ,@IuliuWinkler ,Romania,Group of the European People's Party (Christian Democrats)
+Iuliu WINKLER,https://twitter.com/IuliuWinkler,@IuliuWinkler,Romania,Group of the European People's Party (Christian Democrats)
 Ivan DAVID,,,Czechia,Identity and Democracy Group
 Ivan ŠTEFANEC,https://twitter.com/IvanStefanec,@IvanStefanec,Slovakia,Group of the European People's Party (Christian Democrats)
-Ivan Vilibor SINČIĆ,https://twitter.com/IvanVilibor ,@IvanVilibor ,Croatia,Non-attached Members
+Ivan Vilibor SINČIĆ,https://twitter.com/IvanVilibor,@IvanVilibor,Croatia,Non-attached Members
 Ivars IJABS,https://twitter.com/ijabs,@ijabs,Latvia,Renew Europe Group
 Ivo HRISTOV,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Izabela-Helena KLOC,https://twitter.com/IzabelaKloc,@IzabelaKloc,Poland,European Conservatives and Reformists Group
 Izaskun BILBAO BARANDICA,https://twitter.com/IzaskunBilbaoB,@IzaskunBilbaoB,Spain,Renew Europe Group
 Jaak MADISON,https://twitter.com/jaakmadison,@jaakmadison,Estonia,Identity and Democracy Group
-Jacek SARYUSZ-WOLSKI,https://twitter.com/JSaryuszWolski ,@JSaryuszWolski ,Poland,European Conservatives and Reformists Group
+Jacek SARYUSZ-WOLSKI,https://twitter.com/JSaryuszWolski,@JSaryuszWolski,Poland,European Conservatives and Reformists Group
 Jackie JONES,https://twitter.com/JackieJonesWal1,@JackieJonesWal1,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Jadwiga WIŚNIEWSKA,https://twitter.com/j_wisniewska,@j_wisniewska,Poland,European Conservatives and Reformists Group
-Jake PUGH,https://twitter.com/jake_pugh ,@jake_pugh ,United Kingdom,Non-attached Members
+Jake PUGH,https://twitter.com/jake_pugh,@jake_pugh,United Kingdom,Non-attached Members
 James Alexander GLANCY,https://twitter.com/jaglancy,@jaglancy,United Kingdom,Non-attached Members
 James WELLS,https://twitter.com/jamesfwells,@jamesfwells,United Kingdom,Non-attached Members
 Jan HUITEMA,https://twitter.com/jhuitema,@jhuitema,Netherlands,Renew Europe Group
@@ -335,33 +335,33 @@ Javier MORENO SÁNCHEZ,,,Spain,Group of the Progressive Alliance of Socialists a
 Javier NART,,,Spain,Renew Europe Group
 Javier ZARZALEJOS,https://twitter.com/FZarzalejos,@FZarzalejos,Spain,Group of the European People's Party (Christian Democrats)
 Jean-François JALKH,,,France,Identity and Democracy Group
-Jean-Paul GARRAUD,https://twitter.com/JPGarraud ,@JPGarraud ,France,Identity and Democracy Group
-Jens GEIER,https://twitter.com/EuropaJens ,@EuropaJens ,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Jean-Paul GARRAUD,https://twitter.com/JPGarraud,@JPGarraud,France,Identity and Democracy Group
+Jens GEIER,https://twitter.com/EuropaJens,@EuropaJens,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Jens GIESEKE,,,Germany,Group of the European People's Party (Christian Democrats)
-Jérémy DECERLE,https://twitter.com/JDecerle ,@JDecerle ,France,Renew Europe Group
+Jérémy DECERLE,https://twitter.com/JDecerle,@JDecerle,France,Renew Europe Group
 Jeroen LENAERS,https://twitter.com/jeroen_lenaers,@jeroen_lenaers,Netherlands,Group of the European People's Party (Christian Democrats)
 Jérôme RIVIÈRE,https://twitter.com/jerome_riviere,@jerome_riviere,France,Identity and Democracy Group
 Jerzy BUZEK,https://twitter.com/JerzyBuzek,@JerzyBuzek,Poland,Group of the European People's Party (Christian Democrats)
-Jessica POLFJÄRD,https://twitter.com/jessicapolfjard ,@jessicapolfjard ,Sweden,Group of the European People's Party (Christian Democrats)
-Jessica STEGRUD,https://twitter.com/JessicaStegrud ,@JessicaStegrud ,Sweden,European Conservatives and Reformists Group
+Jessica POLFJÄRD,https://twitter.com/jessicapolfjard,@jessicapolfjard,Sweden,Group of the European People's Party (Christian Democrats)
+Jessica STEGRUD,https://twitter.com/JessicaStegrud,@JessicaStegrud,Sweden,European Conservatives and Reformists Group
 Jill EVANS,https://twitter.com/JillEvansMEP,@JillEvansMEP,United Kingdom,Group of the Greens/European Free Alliance
 Jiří POSPÍŠIL,https://twitter.com/Pospisil_Jiri,@Pospisil_Jiri,Czechia,Group of the European People's Party (Christian Democrats)
-Joachim KUHS,https://twitter.com/Joachim_Kuhs ,@Joachim_Kuhs ,Germany,Identity and Democracy Group
-Joachim SCHUSTER,https://twitter.com/Schuster_MdEP ,@Schuster_MdEP ,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Joachim KUHS,https://twitter.com/Joachim_Kuhs,@Joachim_Kuhs,Germany,Identity and Democracy Group
+Joachim SCHUSTER,https://twitter.com/Schuster_MdEP,@Schuster_MdEP,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Joachim Stanisław BRUDZIŃSKI,https://twitter.com/jbrudzinski,@jbrudzinski,Poland,European Conservatives and Reformists Group
-Joanna KOPCIŃSKA,https://twitter.com/j_kopcinska ,@j_kopcinska ,Poland,European Conservatives and Reformists Group
+Joanna KOPCIŃSKA,https://twitter.com/j_kopcinska,@j_kopcinska,Poland,European Conservatives and Reformists Group
 João FERREIRA,https://twitter.com/joao_ferreira33,@joao_ferreira33,Portugal,Confederal Group of the European United Left - Nordic Green Left
 Joëlle MÉLIN,https://twitter.com/joellemelinrn,@joellemelinrn,France,Identity and Democracy Group
 Johan DANIELSSON,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Johan VAN OVERTVELDT,https://twitter.com/jvanovertveldt ,@jvanovertveldt ,Belgium,European Conservatives and Reformists Group
+Johan VAN OVERTVELDT,https://twitter.com/jvanovertveldt,@jvanovertveldt,Belgium,European Conservatives and Reformists Group
 John David Edward TENNANT,https://twitter.com/JohnTennantMEP,@JohnTennantMEP,United Kingdom,Non-attached Members
-John HOWARTH,https://twitter.com/JohnHowarth1958 ,@JohnHowarth1958 ,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-John LONGWORTH,https://twitter.com/john4brexit ,@john4brexit ,United Kingdom,Non-attached Members
+John HOWARTH,https://twitter.com/JohnHowarth1958,@JohnHowarth1958,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+John LONGWORTH,https://twitter.com/john4brexit,@john4brexit,United Kingdom,Non-attached Members
 Jonás FERNÁNDEZ,https://twitter.com/jonasfernandez,@jonasfernandez,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Jonathan BULLOCK,https://twitter.com/JonathanMEP ,@JonathanMEP ,United Kingdom,Non-attached Members
+Jonathan BULLOCK,https://twitter.com/JonathanMEP,@JonathanMEP,United Kingdom,Non-attached Members
 Jordan BARDELLA,https://twitter.com/J_Bardella,@J_Bardella,France,Identity and Democracy Group
 Jordi CAÑAS,https://twitter.com/jordi_canyas,@jordi_canyas,Spain,Renew Europe Group
-Jörg MEUTHEN,https://twitter.com/Joerg_Meuthen ,@Joerg_Meuthen ,Germany,Identity and Democracy Group
+Jörg MEUTHEN,https://twitter.com/Joerg_Meuthen,@Joerg_Meuthen,Germany,Identity and Democracy Group
 Jorge BUXADÉ VILLALBA,https://twitter.com/jorgebuxade,@jorgebuxade,Spain,European Conservatives and Reformists Group
 Jörgen WARBORN,https://twitter.com/jorgenwarborn,@jorgenwarborn,Sweden,Group of the European People's Party (Christian Democrats)
 José GUSMÃO,https://www.twitter.com/joseggusmao,@joseggusmao,Portugal,Confederal Group of the European United Left - Nordic Green Left
@@ -371,25 +371,25 @@ José Ramón BAUZÁ DÍAZ,https://twitter.com/jrbauza,@jrbauza,Spain,Renew Europ
 Josianne CUTAJAR,https://twitter.com/josiannecutajar,@josiannecutajar,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 József SZÁJER,,,Hungary,Group of the European People's Party (Christian Democrats)
 Juan Fernando LÓPEZ AGUILAR,https://twitter.com/JFLopezAguilar,@JFLopezAguilar,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Juan Ignacio ZOIDO ÁLVAREZ,https://twitter.com/zoidoJI ,@zoidoJI ,Spain,Group of the European People's Party (Christian Democrats)
+Juan Ignacio ZOIDO ÁLVAREZ,https://twitter.com/zoidoJI,@zoidoJI,Spain,Group of the European People's Party (Christian Democrats)
 Jude KIRTON-DARLING,https://twitter.com/Jude_KD,@Jude_KD,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Judith BUNTING,https://twitter.com/judithbuntingld,@judithbuntingld,United Kingdom,Renew Europe Group
 Julie LECHANTEUX,https://twitter.com/JLechanteux,@JLechanteux,France,Identity and Democracy Group
 Julie WARD,https://twitter.com/julie4nw,@julie4nw,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 June Alison MUMMERY,https://twitter.com/june_mummery,@june_mummery,United Kingdom,Non-attached Members
-Juozas OLEKAS,https://twitter.com/juozas_olekas ,@juozas_olekas ,Lithuania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Juozas OLEKAS,https://twitter.com/juozas_olekas,@juozas_olekas,Lithuania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Jutta PAULUS,https://twitter.com/juttapaulusrlp,@juttapaulusrlp,Germany,Group of the Greens/European Free Alliance
 Jytte GUTELAND,https://twitter.com/JytteGuteland,@JytteGuteland,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Karen MELCHIOR,https://twitter.com/karmel80,@karmel80,Denmark,Renew Europe Group
 Karima DELLI,https://twitter.com/KarimaDelli,@KarimaDelli,France,Group of the Greens/European Free Alliance
 Karin KARLSBRO,https://twitter.com/KarinKarlsbro,@KarinKarlsbro,Sweden,Renew Europe Group
-Karlo RESSLER,https://twitter.com/KarloRessler ,@KarloRessler ,Croatia,Group of the European People's Party (Christian Democrats)
-Karol KARSKI,https://twitter.com/profKarski ,@profKarski ,Poland,European Conservatives and Reformists Group
-Karoline EDTSTADLER,https://twitter.com/k_edtstadler ,@k_edtstadler ,Austria,Group of the European People's Party (Christian Democrats)
-Katalin CSEH,https://twitter.com/katka_cseh ,@katka_cseh ,Hungary,Renew Europe Group
+Karlo RESSLER,https://twitter.com/KarloRessler,@KarloRessler,Croatia,Group of the European People's Party (Christian Democrats)
+Karol KARSKI,https://twitter.com/profKarski,@profKarski,Poland,European Conservatives and Reformists Group
+Karoline EDTSTADLER,https://twitter.com/k_edtstadler,@k_edtstadler,Austria,Group of the European People's Party (Christian Democrats)
+Katalin CSEH,https://twitter.com/katka_cseh,@katka_cseh,Hungary,Renew Europe Group
 Katarina BARLEY,https://twitter.com/KATARINABARLEY,@KATARINABARLEY,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Kateřina KONEČNÁ,https://twitter.com/Konecna_K ,@Konecna_K ,Czechia,Confederal Group of the European United Left - Nordic Green Left
-Kathleen VAN BREMPT,https://twitter.com/kvanbrempt ,@kvanbrempt ,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Kateřina KONEČNÁ,https://twitter.com/Konecna_K,@Konecna_K,Czechia,Confederal Group of the European United Left - Nordic Green Left
+Kathleen VAN BREMPT,https://twitter.com/kvanbrempt,@kvanbrempt,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Kati PIRI,https://twitter.com/KatiPiri,@KatiPiri,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Katrin LANGENSIEPEN,https://twitter.com/k_langensiepen,@k_langensiepen,Germany,Group of the Greens/European Free Alliance
 Kim VAN SPARRENTAK,https://twitter.com/kimvsparrentak,@kimvsparrentak,Netherlands,Group of the Greens/European Free Alliance
@@ -397,23 +397,23 @@ Kinga GÁL,,,Hungary,Group of the European People's Party (Christian Democrats)
 Kira Marie PETER-HANSEN,https://twitter.com/kira_mph,@kira_mph,Denmark,Group of the Greens/European Free Alliance
 Klára DOBREV,,,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Klaus BUCHNER,https://twitter.com/Dr_KlausBuchner,@Dr_KlausBuchner,Germany,Group of the Greens/European Free Alliance
-Klemen GROŠELJ,https://twitter.com/KGroselj ,@KGroselj ,Slovenia,Renew Europe Group
+Klemen GROŠELJ,https://twitter.com/KGroselj,@KGroselj,Slovenia,Renew Europe Group
 Konstantinos ARVANITIS,,,Greece,Confederal Group of the European United Left - Nordic Green Left
 Kosma ZŁOTOWSKI,https://twitter.com/KosmaZlotowski,@KosmaZlotowski,Poland,European Conservatives and Reformists Group
 Kostas PAPADAKIS,,,Greece,Non-attached Members
-Kris PEETERS,https://twitter.com/peeters_kris1 ,@peeters_kris1 ,Belgium,Group of the European People's Party (Christian Democrats)
+Kris PEETERS,https://twitter.com/peeters_kris1,@peeters_kris1,Belgium,Group of the European People's Party (Christian Democrats)
 Krzysztof HETMAN,https://twitter.com/hetman_k,@hetman_k,Poland,Group of the European People's Party (Christian Democrats)
 Krzysztof JURGIEL,,,Poland,European Conservatives and Reformists Group
-Lance FORMAN,https://twitter.com/LanceForman ,@LanceForman ,United Kingdom,Non-attached Members
+Lance FORMAN,https://twitter.com/LanceForman,@LanceForman,United Kingdom,Non-attached Members
 Lara WOLTERS,https://twitter.com/larawoltersEU,@larawoltersEU,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament 
 Lars Patrick BERG,https://www.twitter.com/larspatrickberg,@larspatrickberg,Germany,Identity and Democracy Group
-László TRÓCSÁNYI,https://twitter.com/trocsanyi ,@trocsanyi ,Hungary,Group of the European People's Party (Christian Democrats)
+László TRÓCSÁNYI,https://twitter.com/trocsanyi,@trocsanyi,Hungary,Group of the European People's Party (Christian Democrats)
 Laura FERRARA,https://twitter.com/LFerraraM5S,@LFerraraM5S,Italy,Non-attached Members
-Laura HUHTASAARI,https://twitter.com/LauraHuhtasaari ,@LauraHuhtasaari ,Finland,Identity and Democracy Group
+Laura HUHTASAARI,https://twitter.com/LauraHuhtasaari,@LauraHuhtasaari,Finland,Identity and Democracy Group
 Laurence FARRENG,https://twitter.com/laurencefarreng,@laurencefarreng,France,Renew Europe Group
 Lefteris CHRISTOFOROU,https://twitter.com/LefChristoforou,@LefChristoforou,Cyprus,Group of the European People's Party (Christian Democrats)
 Lefteris NIKOLAOU-ALAVANOS,,,Greece,Non-attached Members
-Leila CHAIBI,https://twitter.com/leilachaibi ,@leilachaibi ,France,Confederal Group of the European United Left - Nordic Green Left
+Leila CHAIBI,https://twitter.com/leilachaibi,@leilachaibi,France,Confederal Group of the European United Left - Nordic Green Left
 Lena DÜPONT,,,Germany,Group of the European People's Party (Christian Democrats)
 Leopoldo LÓPEZ GIL,,,Spain,Group of the European People's Party (Christian Democrats)
 Leszek MILLER,https://twitter.com/LeszekMiller,@LeszekMiller,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -421,26 +421,26 @@ Lídia PEREIRA,https://twitter.com/lidiafopereira,@lidiafopereira,Portugal,Group
 Liesje SCHREINEMACHER,https://twitter.com/LSchreinemacher,@LSchreinemacher,Netherlands,Renew Europe Group
 Lina GALVEZ MUÑOZ,https://twitter.com/linagalvezmunoz,@linagalvezmunoz,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Liudas MAŽYLIS,,,Lithuania,Group of the European People's Party (Christian Democrats)
-Lívia JÁRÓKA,https://twitter.com/JarokaLivia ,@JarokaLivia ,Hungary,Group of the European People's Party (Christian Democrats)
-Ljudmila NOVAK,https://twitter.com/LjudmilaNovak ,@LjudmilaNovak ,Slovenia,Group of the European People's Party (Christian Democrats)
+Lívia JÁRÓKA,https://twitter.com/JarokaLivia,@JarokaLivia,Hungary,Group of the European People's Party (Christian Democrats)
+Ljudmila NOVAK,https://twitter.com/LjudmilaNovak,@LjudmilaNovak,Slovenia,Group of the European People's Party (Christian Democrats)
 Lorant-Gyorgy VINCZE,https://twitter.com/vinczelorant,@vinczelorant,Romania,Group of the European People's Party (Christian Democrats)
 Loucas FOURLAS,https://twitter.com/loucas_fourlas,@loucas_fourlas,Cyprus,Group of the European People's Party (Christian Democrats)
 Louis STEDMAN-BRYCE,https://twitter.com/lstedmanbryce,@lstedmanbryce,United Kingdom,Non-attached Members
-Lucia ĎURIŠ NICHOLSONOVÁ,https://twitter.com/LNicholsonova ,@LNicholsonova ,Slovakia,European Conservatives and Reformists Group
-Lucia VUOLO,https://twitter.com/LuciaVuoloEU ,@LuciaVuoloEU ,Italy,Identity and Democracy Group
-Lucy Elizabeth HARRIS,https://twitter.com/Lugey6 ,@Lugey6 ,United Kingdom,Non-attached Members
+Lucia ĎURIŠ NICHOLSONOVÁ,https://twitter.com/LNicholsonova,@LNicholsonova,Slovakia,European Conservatives and Reformists Group
+Lucia VUOLO,https://twitter.com/LuciaVuoloEU,@LuciaVuoloEU,Italy,Identity and Democracy Group
+Lucy Elizabeth HARRIS,https://twitter.com/Lugey6,@Lugey6,United Kingdom,Non-attached Members
 Lucy NETHSINGHA,https://twitter.com/lnethsingha,@lnethsingha,United Kingdom,Renew Europe Group
-Luděk NIEDERMAYER,https://twitter.com/LudekNie ,@LudekNie ,Czechia,Group of the European People's Party (Christian Democrats)
+Luděk NIEDERMAYER,https://twitter.com/LudekNie,@LudekNie,Czechia,Group of the European People's Party (Christian Democrats)
 Luis GARICANO,https://twitter.com/lugaricano,@lugaricano,Spain,Renew Europe Group
 Luisa PORRITT,https://twitter.com/LuisaPorritt,@LuisaPorritt,United Kingdom,Renew Europe Group
-Luisa REGIMENTI,https://twitter.com/luisaregimenti ,@luisaregimenti ,Italy,Identity and Democracy Group
+Luisa REGIMENTI,https://twitter.com/luisaregimenti,@luisaregimenti,Italy,Identity and Democracy Group
 Lukas MANDL,https://twitter.com/lukasmandl,@lukasmandl,Austria,Group of the European People's Party (Christian Democrats)
 Łukasz KOHUT,https://twitter.com/lukaszkohut,@lukaszkohut,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Luke Ming FLANAGAN,https://twitter.com/lukeming,@lukeming,Ireland,Confederal Group of the European United Left - Nordic Green Left
 Magdalena ADAMOWICZ,https://twitter.com/Adamowicz_Magda,@Adamowicz_Magda,Poland,Group of the European People's Party (Christian Democrats)
 Magid MAGID,https://twitter.com/magicmagid,@magicmagid,United Kingdom,Group of the Greens/European Free Alliance
 Mairead McGUINNESS,https://twitter.com/MaireadMcGMEP,@MaireadMcGMEP,Ireland,Group of the European People's Party (Christian Democrats)
-Maite PAGAZAURTUNDÚA,https://twitter.com/maitepagaza ,@maitepagaza ,Spain,Renew Europe Group
+Maite PAGAZAURTUNDÚA,https://twitter.com/maitepagaza,@maitepagaza,Spain,Renew Europe Group
 Malik AZMANI,https://twitter.com/MalikAzmani,@MalikAzmani,Netherlands,Renew Europe Group
 Malin BJÖRK,https://twitter.com/MalinBjork_EU,@MalinBjork_EU,Sweden,Confederal Group of the European United Left - Nordic Green Left
 Manfred WEBER,https://twitter.com/ManfredWeber,@ManfredWeber,Germany,Group of the European People's Party (Christian Democrats)
@@ -448,16 +448,16 @@ Manolis KEFALOGIANNIS,https://twitter.com/M_Kefalogiannis,@M_Kefalogiannis,Greec
 Manon AUBRY,https://twitter.com/manonaubryfr,@manonaubryfr,France,Confederal Group of the European United Left - Nordic Green Left
 Manu PINEDA MARÍN,https://twitter.com/manu_abu_carlos,@manu_abu_carlos,Spain,Confederal Group of the European United Left - Nordic Green Left
 Manuel BOMPARD,https://twitter.com/mbompard,@mbompard,France,Confederal Group of the European United Left - Nordic Green Left
-Manuel PIZARRO,https://twitter.com/MPizarroPorto ,@MPizarroPorto ,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Mara BIZZOTTO,https://twitter.com/marabizzotto ,@marabizzotto ,Italy,Identity and Democracy Group
+Manuel PIZARRO,https://twitter.com/MPizarroPorto,@MPizarroPorto,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Mara BIZZOTTO,https://twitter.com/marabizzotto,@marabizzotto,Italy,Identity and Democracy Group
 Marc BOTENGA,https://www.twitter.com/botengam,@botengam,Belgium,Confederal Group of the European United Left - Nordic Green Left
 Marc TARABELLA,https://twitter.com/marctarabella,@marctarabella,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Marcel KOLAJA,https://twitter.com/PiratKolaja,@PiratKolaja,Czechia,Group of the Greens/European Free Alliance
 Marco CAMPOMENOSI,https://twitter.com/mcampomenosi,@mcampomenosi,Italy,Identity and Democracy Group
-Marco DREOSTO,https://twitter.com/MarcoDreosto ,@MarcoDreosto ,Italy,Identity and Democracy Group
+Marco DREOSTO,https://twitter.com/MarcoDreosto,@MarcoDreosto,Italy,Identity and Democracy Group
 Marco ZANNI,https://twitter.com/Marcozanni86,@Marcozanni86,Italy,Identity and Democracy Group
-Marco ZULLO,https://twitter.com/MarcoZullo ,@MarcoZullo ,Italy,Non-attached Members
-Marek BELKA,https://twitter.com/profMarekBelka ,@profMarekBelka ,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Marco ZULLO,https://twitter.com/MarcoZullo,@MarcoZullo,Italy,Non-attached Members
+Marek BELKA,https://twitter.com/profMarekBelka,@profMarekBelka,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Marek Paweł BALT,https://twitter.com/poselbalt,@poselbalt,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Margarida MARQUES,https://twitter.com/mmargmarques,@mmargmarques,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Margrete AUKEN,https://twitter.com/MargreteAuken,@MargreteAuken,Denmark,Group of the Greens/European Free Alliance
@@ -465,30 +465,30 @@ Maria ARENA,https://twitter.com/Mariearenaps,@Mariearenaps,Belgium,Group of the 
 Maria Da Graça CARVALHO,https://twitter.com/mgracacarvalho,@mgracacarvalho,Portugal,Group of the European People's Party (Christian Democrats)
 Maria GRAPINI,https://twitter.com/mariagrapini,@mariagrapini,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Maria Manuel LEITÃO MARQUES,https://twitter.com/mariamanuellm,@mariamanuellm,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Maria NOICHL,https://twitter.com/MariaNoichl ,@MariaNoichl ,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Maria NOICHL,https://twitter.com/MariaNoichl,@MariaNoichl,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 María Soraya RODRÍGUEZ RAMOS,https://twitter.com/sorayarr_,@sorayarr_,Spain,Renew Europe Group
 Maria SPYRAKI,https://twitter.com/MariaSpyraki,@MariaSpyraki,Greece,Group of the European People's Party (Christian Democrats)
 Maria WALSH,https://twitter.com/mariawalsheu,@mariawalsheu,Ireland,Group of the European People's Party (Christian Democrats)
-Marian-Jean MARINESCU,https://twitter.com/MarianMarinescu ,@MarianMarinescu ,Romania,Group of the European People's Party (Christian Democrats)
+Marian-Jean MARINESCU,https://twitter.com/MarianMarinescu,@MarianMarinescu,Romania,Group of the European People's Party (Christian Democrats)
 Marianne VIND,https://twitter.com/MarianneVind,@MarianneVind,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Marie TOUSSAINT,https://twitter.com/marietouss1,@marietouss1,France,Group of the Greens/European Free Alliance
 Marie-Pierre VEDRENNE,https://twitter.com/mariepierrev,@mariepierrev,France,Renew Europe Group
-Marina KALJURAND,https://twitter.com/MarinaKaljurand ,@MarinaKaljurand ,Estonia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Marina KALJURAND,https://twitter.com/MarinaKaljurand,@MarinaKaljurand,Estonia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Mario FURORE,https://twitter.com/MarioFurore,@MarioFurore,Italy,Non-attached Members
 Marion WALSMANN,https://twitter.com/marionwalsmann,@marionwalsmann,Germany,Group of the European People's Party (Christian Democrats)
 Marisa MATIAS,https://twitter.com/mmatias_,@mmatias_,Portugal,Confederal Group of the European United Left - Nordic Green Left
 Markéta GREGOROVÁ,https://twitter.com/MarketkaG,@MarketkaG,Czechia,Group of the Greens/European Free Alliance
-Markus BUCHHEIT,https://twitter.com/BuchheitMarkus ,@BuchheitMarkus ,Germany,Identity and Democracy Group
+Markus BUCHHEIT,https://twitter.com/BuchheitMarkus,@BuchheitMarkus,Germany,Identity and Democracy Group
 Markus FERBER,https://twitter.com/MarkusFerber,@MarkusFerber,Germany,Group of the European People's Party (Christian Democrats)
 Markus PIEPER,https://twitter.com/markuspiepermep,@markuspiepermep,Germany,Group of the European People's Party (Christian Democrats)
 Marlene MORTLER,,,Germany,Group of the European People's Party (Christian Democrats)
 Martin BUSCHMANN,https://twitter.com/buschmannmartin,@buschmannmartin,Germany,Confederal Group of the European United Left - Nordic Green Left
-Martin Edward DAUBNEY,https://twitter.com/MartinDaubney ,@MartinDaubney ,United Kingdom,Non-attached Members
+Martin Edward DAUBNEY,https://twitter.com/MartinDaubney,@MartinDaubney,United Kingdom,Non-attached Members
 Martin HÄUSLING,https://twitter.com/MartinHaeusling,@MartinHaeusling,Germany,Group of the Greens/European Free Alliance
 Martin HLAVÁČEK,,,Czechia,Renew Europe Group
 Martin HOJSÍK,https://twitter.com/mhojsik,@mhojsik,Slovakia,Renew Europe Group
-Martin HORWOOD,https://twitter.com/MartinChelt ,@MartinChelt ,United Kingdom,Renew Europe Group
-Martin SCHIRDEWAN,https://twitter.com/schirdewan ,@schirdewan ,Germany,Confederal Group of the European United Left - Nordic Green Left
+Martin HORWOOD,https://twitter.com/MartinChelt,@MartinChelt,United Kingdom,Renew Europe Group
+Martin SCHIRDEWAN,https://twitter.com/schirdewan,@schirdewan,Germany,Confederal Group of the European United Left - Nordic Green Left
 Martin SONNEBORN,https://twitter.com/MartinSonneborn,@MartinSonneborn,Germany,Non-attached Members
 Martina ANDERSON,https://twitter.com/M_AndersonSF,@M_AndersonSF,United Kingdom,Confederal Group of the European United Left - Nordic Green Left
 Martina DLABAJOVÁ,https://twitter.com/Mdlabajova,@Mdlabajova,Czechia,Renew Europe Group
@@ -499,20 +499,20 @@ Massimiliano SMERIGLIO,https://twitter.com/maxsmeriglio,@maxsmeriglio,Italy,Grou
 Massimo CASANOVA,,,Italy,Identity and Democracy Group
 Mathilde ANDROUËT,,,France,Identity and Democracy Group
 Matt CARTHY,https://twitter.com/mattcarthy,@mattcarthy,Ireland,Confederal Group of the European United Left - Nordic Green Left
-Matteo ADINOLFI,https://twitter.com/adinolfi_matteo ,@adinolfi_matteo ,Italy,Identity and Democracy Group
+Matteo ADINOLFI,https://twitter.com/adinolfi_matteo,@adinolfi_matteo,Italy,Identity and Democracy Group
 Matthew PATTEN,https://twitter.com/math_patten,@math_patten,United Kingdom,Non-attached Members
-Mauri PEKKARINEN,https://twitter.com/PekkarinenMauri ,@PekkarinenMauri ,Finland,Renew Europe Group
+Mauri PEKKARINEN,https://twitter.com/PekkarinenMauri,@PekkarinenMauri,Finland,Renew Europe Group
 Maxette PIRBAKAS,,,France,Identity and Democracy Group
 Maximilian KRAH,https://twitter.com/krahmax,@krahmax,Germany,Identity and Democracy Group
-Mazaly AGUILAR,https://twitter.com/MazalyAguilar ,@MazalyAguilar ,Spain,European Conservatives and Reformists Group
+Mazaly AGUILAR,https://twitter.com/MazalyAguilar,@MazalyAguilar,Spain,European Conservatives and Reformists Group
 Miapetra KUMPULA-NATRI,https://twitter.com/miapetrakumpula,@miapetrakumpula,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Michael BLOSS,https://twitter.com/michabl,@michabl,Germany,Group of the Greens/European Free Alliance
-Michael GAHLER,https://twitter.com/michaelgahler,@michaelgahler ,Germany,Group of the European People's Party (Christian Democrats)
+Michael GAHLER,https://twitter.com/michaelgahler,@michaelgahler,Germany,Group of the European People's Party (Christian Democrats)
 Michael HEAVER,https://twitter.com/michael_heaver,@michael_heaver,United Kingdom,Non-attached Members
-Michaela ŠOJDROVÁ,https://twitter.com/msojdrova ,@msojdrova ,Czechia,Group of the European People's Party (Christian Democrats)
+Michaela ŠOJDROVÁ,https://twitter.com/msojdrova,@msojdrova,Czechia,Group of the European People's Party (Christian Democrats)
 Michal ŠIMEČKA,,,Slovakia,Renew Europe Group
 Michal WIEZIK,,,Slovakia,Group of the European People's Party (Christian Democrats)
-Michèle RIVASI,https://twitter.com/MicheleRivasi ,@MicheleRivasi,France,Group of the Greens/European Free Alliance
+Michèle RIVASI,https://twitter.com/MicheleRivasi,@MicheleRivasi,France,Group of the Greens/European Free Alliance
 Mick WALLACE,https://twitter.com/wallacemick,@wallacemick,Ireland,Confederal Group of the European United Left - Nordic Green Left
 Miguel URBÁN CRESPO,https://twitter.com/MiguelUrban,@MiguelUrban,Spain,Confederal Group of the European United Left - Nordic Green Left
 Mihai TUDOSE,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -524,14 +524,14 @@ Mircea-Gheorghe HAVA,,,Romania,Group of the European People's Party (Christian D
 Miriam DALLI,https://twitter.com/Miriamdalli,@Miriamdalli,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Miroslav ČÍŽ,,,Slovakia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Miroslav RADAČOVSKÝ,,,Slovakia,Non-attached Members
-Mislav KOLAKUŠIĆ,https://twitter.com/MKolakusic ,@MKolakusic ,Croatia,Non-attached Members
+Mislav KOLAKUŠIĆ,https://twitter.com/MKolakusic,@MKolakusic,Croatia,Non-attached Members
 Mohammed CHAHIM,https://twitter.com/MChahim,@MChahim,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Molly SCOTT CATO,https://twitter.com/MollyMEP,@MollyMEP,United Kingdom,Group of the Greens/European Free Alliance
 Monica SEMEDO,https://twitter.com/MonicaSemedoLux,@MonicaSemedoLux,Luxembourg,Renew Europe Group
-Mónica Silvana GONZÁLEZ,https://twitter.com/MonicaSilvanaG ,@MonicaSilvanaG ,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Monika BEŇOVÁ,https://twitter.com/monika_benova ,@monika_benova ,Slovakia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Monika HOHLMEIER,https://twitter.com/MHohlmeier ,@MHohlmeier ,Germany,Group of the European People's Party (Christian Democrats)
-Monika VANA,https://twitter.com/MonikaVana ,@MonikaVana ,Austria,Group of the Greens/European Free Alliance
+Mónica Silvana GONZÁLEZ,https://twitter.com/MonicaSilvanaG,@MonicaSilvanaG,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Monika BEŇOVÁ,https://twitter.com/monika_benova,@monika_benova,Slovakia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Monika HOHLMEIER,https://twitter.com/MHohlmeier,@MHohlmeier,Germany,Group of the European People's Party (Christian Democrats)
+Monika VANA,https://twitter.com/MonikaVana,@MonikaVana,Austria,Group of the Greens/European Free Alliance
 Moritz KÖRNER,https://twitter.com/moritzkoerner,@moritzkoerner,Germany,Renew Europe Group
 Morten LØKKEGAARD,https://twitter.com/loekkegaard_mep,@loekkegaard_mep,Denmark,Renew Europe Group
 Morten PETERSEN,https://twitter.com/mortenhelveg,@mortenhelveg,Denmark,Renew Europe Group
@@ -539,8 +539,8 @@ Mounir SATOURI,https://twitter.com/mounirsatouri,@mounirsatouri,France,Group of 
 Nacho SÁNCHEZ AMOR,https://twitter.com/NachoSAmor,@NachoSAmor,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nadine MORANO,https://twitter.com/nadine__morano,@nadine__morano,France,Group of the European People's Party (Christian Democrats)
 Naomi LONG,https://twitter.com/naomi_long,@naomi_long,United Kingdom,Renew Europe Group
-Nathalie COLIN-OESTERLÉ,https://twitter.com/ncolin_oesterle ,@ncolin_oesterle ,France,Group of the European People's Party (Christian Democrats)
-Nathalie LOISEAU,https://twitter.com/NathalieLoiseau ,@NathalieLoiseau ,France,Renew Europe Group
+Nathalie COLIN-OESTERLÉ,https://twitter.com/ncolin_oesterle,@ncolin_oesterle,France,Group of the European People's Party (Christian Democrats)
+Nathalie LOISEAU,https://twitter.com/NathalieLoiseau,@NathalieLoiseau,France,Renew Europe Group
 Nathan GILL,https://www.twitter.com/NathanGillMEP,@NathanGillMEP,United Kingdom,Non-attached Members
 Neena GILL,https://twitter.com/NeenaGmep,@NeenaGmep,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Niclas HERBST,,,Germany,Group of the European People's Party (Christian Democrats)
@@ -550,40 +550,40 @@ Nicola DANTI,https://twitter.com/DantiNicola,@DantiNicola,Italy,Group of the Pro
 Nicola PROCACCINI,https://twitter.com/nprocaccini,@Nprocaccini,Italy,European Conservatives and Reformists Group
 Nicolae ȘTEFĂNUȚA,https://twitter.com/nicustefanuta,@nicustefanuta,Romania,Renew Europe Group
 Nicolas BAY,https://twitter.com/NicolasBay_,@NicolasBay_,France,Identity and Democracy Group
-Nicolás GONZALEZ CASARES,https://twitter.com/nicogoncas ,@nicogoncas ,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Nicolas SCHMIT,https://twitter.com/nicolasschmit2 ,@nicolasschmit2 ,Luxembourg,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Nicolaus FEST,https://twitter.com/Nicolaus_Fest ,@Nicolaus_Fest ,Germany,Identity and Democracy Group
+Nicolás GONZALEZ CASARES,https://twitter.com/nicogoncas,@nicogoncas,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Nicolas SCHMIT,https://twitter.com/nicolasschmit2,@nicolasschmit2,Luxembourg,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Nicolaus FEST,https://twitter.com/Nicolaus_Fest,@Nicolaus_Fest,Germany,Identity and Democracy Group
 Niels FUGLSANG,https://twitter.com/NielsFuglsang,@NielsFuglsang,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nigel FARAGE,https://twitter.com/Nigel_Farage,@Nigel_Farage,United Kingdom,Non-attached Members
 Niklas NIENASS,https://twitter.com/nnienass,@nnienass,Germany,Group of the Greens/European Free Alliance
 Nikolaj VILLUMSEN,https://twitter.com/nvillumsen,@nvillumsen,Denmark,Confederal Group of the European United Left - Nordic Green Left
 Nikos ANDROULAKIS,https://twitter.com/androulakisnick,@androulakisnick,Greece,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nils TORVALDS,https://twitter.com/nilstorvalds,@nilstorvalds,Finland,Renew Europe Group
-Nils UŠAKOVS,https://twitter.com/nilsusakovs ,@nilsusakovs ,Latvia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Niyazi KIZILYÜREK,https://twitter.com/NKizilyurek ,@NKizilyurek ,Cyprus,Confederal Group of the European United Left - Nordic Green Left
+Nils UŠAKOVS,https://twitter.com/nilsusakovs,@nilsusakovs,Latvia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Niyazi KIZILYÜREK,https://twitter.com/NKizilyurek,@NKizilyurek,Cyprus,Confederal Group of the European United Left - Nordic Green Left
 Norbert LINS,,,Germany,Group of the European People's Party (Christian Democrats)
 Norbert NEUSER,,,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Nosheena MOBARIK Baroness,https://twitter.com/NosheenaMobarik,@NosheenaMobarik,United Kingdom,European Conservatives and Reformists Group
-Nuno MELO,https://twitter.com/NunoMeloCDS ,@NunoMeloCDS ,Portugal,Group of the European People's Party (Christian Democrats)
-Olivier CHASTEL,https://twitter.com/OChastel ,@OChastel ,Belgium,Renew Europe Group
+Nuno MELO,https://twitter.com/NunoMeloCDS,@NunoMeloCDS,Portugal,Group of the European People's Party (Christian Democrats)
+Olivier CHASTEL,https://twitter.com/OChastel,@OChastel,Belgium,Renew Europe Group
 Ondřej KNOTEK,https://twitter.com/KnotekOndrej,@KnotekOndrej,Czechia,Renew Europe Group
 Ondřej KOVAŘÍK,https://twitter.com/OKovarikMEP,@OkovarikMEP,Czechia,Renew Europe Group
 Oscar LANCINI,https://twitter.com/doscarlancini,@doscarlancini,Italy,Identity and Democracy Group
-Othmar KARAS,https://twitter.com/othmar_karas ,@othmar_karas,Austria,Group of the European People's Party (Christian Democrats)
+Othmar KARAS,https://twitter.com/othmar_karas,@othmar_karas,Austria,Group of the European People's Party (Christian Democrats)
 Özlem DEMIREL,https://twitter.com/oezlemademirel,@oezlemademirel,Germany,Confederal Group of the European United Left - Nordic Green Left
 Pablo ARIAS ECHEVERRÍA,,,Spain,Group of the European People's Party (Christian Democrats)
 Paolo BORCHIA,https://twitter.com/paoloborchia,@paoloborchia,Italy,Identity and Democracy Group
 Paolo DE CASTRO,https://twitter.com/paolodecastro,@paolodecastro,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pär HOLMGREN,https://twitter.com/parholmgren,@parholmgren,Sweden,Group of the Greens/European Free Alliance
-Pascal ARIMONT,https://twitter.com/pascal_arimont ,@pascal_arimont ,Belgium,Group of the European People's Party (Christian Democrats)
-Pascal CANFIN,https://twitter.com/pcanfin ,@pcanfin ,France,Renew Europe Group
-Pascal DURAND,https://twitter.com/PDurandOfficiel ,@PDurandOfficiel ,France,Renew Europe Group
+Pascal ARIMONT,https://twitter.com/pascal_arimont,@pascal_arimont,Belgium,Group of the European People's Party (Christian Democrats)
+Pascal CANFIN,https://twitter.com/pcanfin,@pcanfin,France,Renew Europe Group
+Pascal DURAND,https://twitter.com/PDurandOfficiel,@PDurandOfficiel,France,Renew Europe Group
 Patrick BREYER,https://twitter.com/echo_pbreyer,@echo_pbreyer,Germany,Group of the Greens/European Free Alliance
 Patrizia TOIA,https://twitter.com/toiapatrizia,@toiapatrizia,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Patryk JAKI,https://twitter.com/PatrykJaki ,@PatrykJaki ,Poland,European Conservatives and Reformists Group
+Patryk JAKI,https://twitter.com/PatrykJaki,@PatrykJaki,Poland,European Conservatives and Reformists Group
 Paul TANG,https://twitter.com/paultang,@paultang,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Paulo RANGEL,https://twitter.com/paulorangel_pt,@paulorangel_pt,Portugal,Group of the European People's Party (Christian Democrats)
-Pedro MARQUES,https://twitter.com/pmdjmarques ,@pmdjmarques ,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Pedro MARQUES,https://twitter.com/pmdjmarques,@pmdjmarques,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pedro SILVA PEREIRA,,,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pernando BARRENA ARZA,https://twitter.com/pernandobarrena,@pernandobarrena,Spain,Confederal Group of the European United Left - Nordic Green Left
 Pernille WEISS,https://twitter.com/WeissPernille,@WeissPernille,Denmark,Group of the European People's Party (Christian Democrats)
@@ -591,19 +591,19 @@ Petar VITANOV,,,Bulgaria,Group of the Progressive Alliance of Socialists and Dem
 Peter JAHR,https://twitter.com/peter_jahr,@peter_jahr,Germany,Group of the European People's Party (Christian Democrats)
 Peter LIESE,https://twitter.com/peterliese,@peterliese,Germany,Group of the European People's Party (Christian Democrats)
 Peter LUNDGREN,,,Sweden,European Conservatives and Reformists Group
-Peter POLLÁK,https://twitter.com/Peter_Pollak ,@Peter_Pollak ,Slovakia,Group of the European People's Party (Christian Democrats)
+Peter POLLÁK,https://twitter.com/Peter_Pollak,@Peter_Pollak,Slovakia,Group of the European People's Party (Christian Democrats)
 Peter van DALEN,https://twitter.com/petervdalen,@petervdalen,Netherlands,Group of the European People's Party (Christian Democrats)
 Petra DE SUTTER,https://twitter.com/pdsutter,@pdsutter,Belgium,Group of the Greens/European Free Alliance
 Petra KAMMEREVERT,,,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Petras AUŠTREVIČIUS,https://twitter.com/petras_petras,@petras_petras,Lithuania,Renew Europe Group
 Petri SARVAMAA,https://twitter.com/petrisarvamaa,@petrisarvamaa,Finland,Group of the European People's Party (Christian Democrats)
-Petros KOKKALIS,https://twitter.com/PetrosKokkalis ,@PetrosKokkalis ,Greece,Confederal Group of the European United Left - Nordic Green Left
-Phil BENNION,https://twitter.com/PhilBennion ,@PhilBennion ,United Kingdom,Renew Europe Group
-Philippe LAMBERTS,https://twitter.com/ph_lamberts ,@ph_lamberts ,Belgium,Group of the Greens/European Free Alliance
-Philippe OLIVIER,https://twitter.com/PhOlivierRN ,@PhOlivierRN ,France,Identity and Democracy Group
+Petros KOKKALIS,https://twitter.com/PetrosKokkalis,@PetrosKokkalis,Greece,Confederal Group of the European United Left - Nordic Green Left
+Phil BENNION,https://twitter.com/PhilBennion,@PhilBennion,United Kingdom,Renew Europe Group
+Philippe LAMBERTS,https://twitter.com/ph_lamberts,@ph_lamberts,Belgium,Group of the Greens/European Free Alliance
+Philippe OLIVIER,https://twitter.com/PhOlivierRN,@PhOlivierRN,France,Identity and Democracy Group
 Pierfrancesco MAJORINO,https://twitter.com/pfmajorino,@pfmajorino,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Piernicola PEDICINI,https://twitter.com/PediciniM5S,@PediciniM5S,Italy,Non-attached Members
-Pierre KARLESKIND,https://twitter.com/Pierre_Ka ,@Pierre_Ka ,France,Renew Europe Group
+Pierre KARLESKIND,https://twitter.com/Pierre_Ka,@Pierre_Ka,France,Renew Europe Group
 Pierre LARROUTUROU,https://twitter.com/larrouturou,@larrouturou,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pierrette Gabrielle HERZBERGER-FOFANA,,,Germany,Group of the Greens/European Free Alliance
 Pietro BARTOLO,https://twitter.com/bartolopietro1,@bartolopietro1,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -611,14 +611,14 @@ Pietro FIOCCHI,https://twitter.com/FiocchiPietro,@FiocchiPietro,Italy,European C
 Pilar del CASTILLO VERA,https://twitter.com/delcastillop,@delcastillop,Spain,Group of the European People's Party (Christian Democrats)
 Pina PICIERNO,https://twitter.com/pinapic,@pinapic,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Predrag Fred MATIĆ,https://twitter.com/fred_matic,@fred_matic,Croatia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Radan KANEV,https://twitter.com/rmkanev ,@rmkanev ,Bulgaria,Group of the European People's Party (Christian Democrats)
-Radka MAXOVÁ,https://twitter.com/radkamaxova ,@radkamaxova ,Czechia,Renew Europe Group
+Radan KANEV,https://twitter.com/rmkanev,@rmkanev,Bulgaria,Group of the European People's Party (Christian Democrats)
+Radka MAXOVÁ,https://twitter.com/radkamaxova,@radkamaxova,Czechia,Renew Europe Group
 Radosław SIKORSKI,https://twitter.com/sikorskiradek,@sikorskiradek,Poland,Group of the European People's Party (Christian Democrats)
 Raffaele FITTO,https://twitter.com/raffaelefitto,@raffaelefitto,Italy,European Conservatives and Reformists Group
-Raffaele STANCANELLI,https://twitter.com/r_stancanelli ,@r_stancanelli ,Italy,European Conservatives and Reformists Group
+Raffaele STANCANELLI,https://twitter.com/r_stancanelli,@r_stancanelli,Italy,European Conservatives and Reformists Group
 Rainer WIELAND,,,Germany,Group of the European People's Party (Christian Democrats)
 Ralf SEEKATZ,,,Germany,Group of the European People's Party (Christian Democrats)
-Ramona STRUGARIU,https://twitter.com/RamonaStrugariu ,@RamonaStrugariu ,Romania,Renew Europe Group
+Ramona STRUGARIU,https://twitter.com/RamonaStrugariu,@RamonaStrugariu,Romania,Renew Europe Group
 Raphaël GLUCKSMANN,https://twitter.com/rglucks1,@rglucks1,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Rasa JUKNEVIČIENĖ,https://twitter.com/rjukneviciene,@rjukneviciene,Lithuania,Group of the European People's Party (Christian Democrats)
 Rasmus ANDRESEN,https://twitter.com/RasmusAndresen,@RasmusAndresen,Germany,Group of the Greens/European Free Alliance
@@ -631,24 +631,24 @@ Robert HAJŠEL,https://twitter.com/RobertHajsel,@RobertHajsel,Slovakia,Group of 
 Robert ROOS,https://twitter.com/rob_roos,@rob_roos,Netherlands,European Conservatives and Reformists Group
 Robert ROWLAND,https://twitter.com/RowlandBrexitSE,@RowlandBrexitSE,United Kingdom,Non-attached Members
 Roberta METSOLA,https://twitter.com/RobertaMetsola,@RobertaMetsola,Malta,Group of the European People's Party (Christian Democrats)
-Roberts ZĪLE,https://twitter.com/robertszile ,@robertszile ,Latvia,European Conservatives and Reformists Group
+Roberts ZĪLE,https://twitter.com/robertszile,@robertszile,Latvia,European Conservatives and Reformists Group
 Roman HAIDER,,,Austria,Identity and Democracy Group
 Romana TOMC,https://twitter.com/RomanaTomc,@RomanaTomc,Slovenia,Group of the European People's Party (Christian Democrats)
 Romeo FRANZ,https://twitter.com/romeofranz1,@romeofranz1,Germany,Group of the Greens/European Free Alliance
 Rory PALMER,https://twitter.com/rory_palmer,@rory_palmer,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Rosa D'AMATO,https://twitter.com/rosadamato634 ,@rosadamato634 ,Italy,Non-attached Members
+Rosa D'AMATO,https://twitter.com/rosadamato634,@rosadamato634,Italy,Non-attached Members
 Rosa ESTARÀS FERRAGUT,,,Spain,Group of the European People's Party (Christian Democrats)
-Rosanna CONTE,https://twitter.com/Rosannaconte_ ,@Rosannaconte_ ,Italy,Identity and Democracy Group
-Rovana PLUMB,https://twitter.com/RovanaPlumbMM ,@RovanaPlumbMM ,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Rosanna CONTE,https://twitter.com/Rosannaconte_,@Rosannaconte_,Italy,Identity and Democracy Group
+Rovana PLUMB,https://twitter.com/RovanaPlumbMM,@RovanaPlumbMM,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Róża THUN UND HOHENSTEIN,https://twitter.com/rozathun,@rozathun,Poland,Group of the European People's Party (Christian Democrats)
-Rupert LOWE,https://twitter.com/RupertLowe10 ,@RupertLowe10 ,United Kingdom,Non-attached Members
+Rupert LOWE,https://twitter.com/RupertLowe10,@RupertLowe10,United Kingdom,Non-attached Members
 Ruža TOMAŠIĆ,https://twitter.com/ruzatomasic,@ruzatomasic,Croatia,European Conservatives and Reformists Group
 Ryszard Antoni LEGUTKO,,,Poland,European Conservatives and Reformists Group
 Ryszard CZARNECKI,https://twitter.com/r_czarnecki,@r_czarnecki,Poland,European Conservatives and Reformists Group
 Sabine VERHEYEN,https://twitter.com/sabineverheyen,@sabineverheyen,Germany,Group of the European People's Party (Christian Democrats)
 Sabrina PIGNEDOLI,https://twitter.com/SabriPignedoli,@SabriPignedoli,Italy,Non-attached Members
-Salima YENBOU,https://twitter.com/salima_yenbou ,@salima_yenbou ,France,Group of the Greens/European Free Alliance
-Samira RAFAELA,https://twitter.com/samiraraf ,@samiraraf ,Netherlands,Renew Europe Group
+Salima YENBOU,https://twitter.com/salima_yenbou,@salima_yenbou,France,Group of the Greens/European Free Alliance
+Samira RAFAELA,https://twitter.com/samiraraf,@samiraraf,Netherlands,Renew Europe Group
 Sándor RÓNAI,https://twitter.com/sandor_ronai,@sandor_ronai,Hungary,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sandra KALNIETE,https://twitter.com/kalniete,@kalniete,Latvia,Group of the European People's Party (Christian Democrats)
 Sandra PEREIRA,,,Portugal,Confederal Group of the European United Left - Nordic Green Left
@@ -657,43 +657,43 @@ Sara SKYTTEDAL,https://twitter.com/skyttedal,@skyttedal,Sweden,Group of the Euro
 Sarah WIENER,,,Austria,Group of the Greens/European Free Alliance
 Saskia BRICMONT,https://twitter.com/bricmontsaskia,@bricmontsaskia,Belgium,Group of the Greens/European Free Alliance
 Scott AINSLIE,https://twitter.com/ScottMEPLondon,@ScottMEPLondon,United Kingdom,Group of the Greens/European Free Alliance
-Seán KELLY,https://twitter.com/SeanKellyMEP ,@SeanKellyMEP ,Ireland,Group of the European People's Party (Christian Democrats)
+Seán KELLY,https://twitter.com/SeanKellyMEP,@SeanKellyMEP,Ireland,Group of the European People's Party (Christian Democrats)
 Seb DANCE,https://twitter.com/SebDance,@SebDance,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sergei STANISHEV,https://twitter.com/SergeiStanishev,@SergeiStanishev,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sergey LAGODINSKY,https://twitter.com/slagodinsky,@slagodinsky,Germany,Group of the Greens/European Free Alliance
 Shaffaq MOHAMMED,https://twitter.com/shaffaqmohd,@shaffaqmohd,United Kingdom,Renew Europe Group
 Sheila RITCHIE,https://twitter.com/europesheila,@europesheila,United Kingdom,Renew Europe Group
 Siegfried MUREŞAN,https://twitter.com/SMuresan,@SMuresan,Romania,Group of the European People's Party (Christian Democrats)
-Silvia MODIG,https://twitter.com/silviamodig ,@silviamodig ,Finland,Confederal Group of the European United Left - Nordic Green Left
+Silvia MODIG,https://twitter.com/silviamodig,@silviamodig,Finland,Confederal Group of the European United Left - Nordic Green Left
 Silvia SARDONE,https://twitter.com/SardoneSilvia,@SardoneSilvia,Italy,Identity and Democracy Group
-Silvio BERLUSCONI,https://twitter.com/berlusconi ,@berlusconi ,Italy,Group of the European People's Party (Christian Democrats)
-Simona BALDASSARRE,https://twitter.com/SR_Baldassarre ,@SR_Baldassarre ,Italy,Identity and Democracy Group
+Silvio BERLUSCONI,https://twitter.com/berlusconi,@berlusconi,Italy,Group of the European People's Party (Christian Democrats)
+Simona BALDASSARRE,https://twitter.com/SR_Baldassarre,@SR_Baldassarre,Italy,Identity and Democracy Group
 Simona BONAFÈ,https://twitter.com/simonabonafe,@simonabonafe,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Simone SCHMIEDTBAUER,,,Austria,Group of the European People's Party (Christian Democrats)
 Sira REGO,https://twitter.com/SIRAREGO,@SIRAREGO,Spain,Confederal Group of the European United Left - Nordic Green Left
 Sirpa PIETIKÄINEN,https://twitter.com/spietikainen,@spietikainen,Finland,Group of the European People's Party (Christian Democrats)
 Ska KELLER,https://twitter.com/SkaKeller,@SkaKeller,Germany,Group of the Greens/European Free Alliance
 Sophia in 't VELD,https://twitter.com/SophieintVeld,@SophieintVeld,Netherlands,Renew Europe Group
-Søren Gade GADE,https://twitter.com/SoerenGade ,@SoerenGade ,Denmark,Renew Europe Group
+Søren Gade GADE,https://twitter.com/SoerenGade,@SoerenGade,Denmark,Renew Europe Group
 Stanislav POLČÁK,https://twitter.com/stanislavpolcak,@stanislavpolcak,Czechia,Group of the European People's Party (Christian Democrats)
 Stasys JAKELIŪNAS,,,Lithuania,Group of the Greens/European Free Alliance
-Stefan BERGER,https://twitter.com/DrStefanBerger ,@DrStefanBerger ,Germany,Group of the European People's Party (Christian Democrats)
-Stefania ZAMBELLI,https://twitter.com/ZambelliLega ,@ZambelliLega ,Italy,Identity and Democracy Group
+Stefan BERGER,https://twitter.com/DrStefanBerger,@DrStefanBerger,Germany,Group of the European People's Party (Christian Democrats)
+Stefania ZAMBELLI,https://twitter.com/ZambelliLega,@ZambelliLega,Italy,Identity and Democracy Group
 Stelios KOULOGLOU,https://twitter.com/SteliosKoul,@SteliosKoul,Greece,Confederal Group of the European United Left - Nordic Green Left
 Stelios KYMPOUROPOULOS,https://twitter.com/kympouropoulos,@kympouropoulos,Greece,Group of the European People's Party (Christian Democrats)
-Stéphane BIJOUX,https://twitter.com/StephaneBIJOUX ,@StephaneBIJOUX ,France,Renew Europe Group
-Stéphane SÉJOURNÉ,https://twitter.com/steph_sejourne ,@steph_sejourne ,France,Renew Europe Group
+Stéphane BIJOUX,https://twitter.com/StephaneBIJOUX,@StephaneBIJOUX,France,Renew Europe Group
+Stéphane SÉJOURNÉ,https://twitter.com/steph_sejourne,@steph_sejourne,France,Renew Europe Group
 Stéphanie YON-COURTIN,https://twitter.com/s_yoncourtin,@s_yoncourtin,France,Renew Europe Group
 Susana SOLÍS PÉREZ,https://twitter.com/susanasolisp,@susanasolisp,Spain,Renew Europe Group
-Susanna CECCARDI,https://twitter.com/SusannaCeccardi ,@SusannaCeccardi ,Italy,Identity and Democracy Group
-Sven GIEGOLD,https://twitter.com/sven_giegold ,@sven_giegold ,Germany,Group of the Greens/European Free Alliance
-Sven MIKSER,https://twitter.com/svenmikser ,@svenmikser ,Estonia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Susanna CECCARDI,https://twitter.com/SusannaCeccardi,@SusannaCeccardi,Italy,Identity and Democracy Group
+Sven GIEGOLD,https://twitter.com/sven_giegold,@sven_giegold,Germany,Group of the Greens/European Free Alliance
+Sven MIKSER,https://twitter.com/svenmikser,@svenmikser,Estonia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sven SCHULZE,https://twitter.com/schulzeeuropa,@schulzeeuropa,Germany,Group of the European People's Party (Christian Democrats)
-Sven SIMON,https://twitter.com/svensimon ,@svensimon ,Germany,Group of the European People's Party (Christian Democrats)
+Sven SIMON,https://twitter.com/svensimon,@svensimon,Germany,Group of the European People's Party (Christian Democrats)
 Svenja HAHN,https://twitter.com/svenja_hahn,@svenja_hahn,Germany,Renew Europe Group
 Sylvia LIMMER,,,Germany,Identity and Democracy Group
 Sylvie BRUNET,https://twitter.com/syl_brunet,@syl_brunet,France,Renew Europe Group
-Sylvie GUILLAUME,https://twitter.com/sylvieguillaume ,@sylvieguillaume ,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Sylvie GUILLAUME,https://twitter.com/sylvieguillaume,@sylvieguillaume,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sylwia SPUREK,https://twitter.com/sylwiaspurek,@sylwiaspurek,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tamás DEUTSCH,https://twitter.com/dajcstomi,@dajcstomi,Hungary,Group of the European People's Party (Christian Democrats)
 Tanja FAJON,https://twitter.com/tfajon,@tfajon,Slovenia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -707,29 +707,29 @@ Tiemo WÖLKEN,https://twitter.com/woelken,@woelken,Germany,Group of the Progress
 Tilly METZ,,,Luxembourg,Group of the Greens/European Free Alliance
 Tineke STRIK,https://twitter.com/tineke_strik,@tineke_strik,Netherlands,Group of the Greens/European Free Alliance
 Tiziana BEGHIN,https://twitter.com/beghin_t,@beghin_t,Italy,Non-attached Members
-Tom BERENDSEN,https://twitter.com/tbwberendsen ,@tbwberendsen ,Netherlands,Group of the European People's Party (Christian Democrats)
-Tom VANDENDRIESSCHE,https://twitter.com/TomVandendriess ,@TomVandendriess ,Belgium,Identity and Democracy Group
-Tomas TOBÉ,https://twitter.com/tomastobe ,@tomastobe ,Sweden,Group of the European People's Party (Christian Democrats)
+Tom BERENDSEN,https://twitter.com/tbwberendsen,@tbwberendsen,Netherlands,Group of the European People's Party (Christian Democrats)
+Tom VANDENDRIESSCHE,https://twitter.com/TomVandendriess,@TomVandendriess,Belgium,Identity and Democracy Group
+Tomas TOBÉ,https://twitter.com/tomastobe,@tomastobe,Sweden,Group of the European People's Party (Christian Democrats)
 Tomáš ZDECHOVSKÝ,https://twitter.com/TomZdechovskyEP,@TomZdechovskyEP,Czechia,Group of the European People's Party (Christian Democrats)
-Tomasz FRANKOWSKI,https://twitter.com/TFrankowski21 ,@TFrankowski21 ,Poland,Group of the European People's Party (Christian Democrats)
-Tomasz Piotr PORĘBA,https://twitter.com/TomaszPoreba ,@TomaszPoreba ,Poland,European Conservatives and Reformists Group
-Tomislav SOKOL,https://twitter.com/TomislavSokol ,@TomislavSokol ,Croatia,Group of the European People's Party (Christian Democrats)
-Tonino PICULA,https://twitter.com/TPicula ,@TPicula ,Croatia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Tomasz FRANKOWSKI,https://twitter.com/TFrankowski21,@TFrankowski21,Poland,Group of the European People's Party (Christian Democrats)
+Tomasz Piotr PORĘBA,https://twitter.com/TomaszPoreba,@TomaszPoreba,Poland,European Conservatives and Reformists Group
+Tomislav SOKOL,https://twitter.com/TomislavSokol,@TomislavSokol,Croatia,Group of the European People's Party (Christian Democrats)
+Tonino PICULA,https://twitter.com/TPicula,@TPicula,Croatia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Traian BĂSESCU,https://twitter.com/tbasescu,@tbasescu,Romania,Group of the European People's Party (Christian Democrats)
 Tsvetelina PENKOVA,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tudor CIUHODARU,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Udo BULLMANN,https://twitter.com/UdoBullmann ,@UdoBullmann ,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Udo BULLMANN,https://twitter.com/UdoBullmann,@UdoBullmann,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Ulrike MÜLLER,https://twitter.com/ulimuellermdep,@ulimuellermdep,Germany,Renew Europe Group
 Urmas PAET,https://twitter.com/urmaspaet,@urmaspaet,Estonia,Renew Europe Group
 Valdemar TOMAŠEVSKI,,,Lithuania,European Conservatives and Reformists Group
 Valentino GRANT,https://twitter.com/ValentinoGrant,@ValentinoGrant,Italy,Identity and Democracy Group
 Valerie HAYER,https://twitter.com/valeriehayer,@valeriehayer,France,Renew Europe Group
-Valter FLEGO,https://twitter.com/ValterFlego ,@ValterFlego ,Croatia,Renew Europe Group
-Vangelis MEIMARAKIS,https://twitter.com/v_meimarakis ,@v_meimarakis ,Greece,Group of the European People's Party (Christian Democrats)
+Valter FLEGO,https://twitter.com/ValterFlego,@ValterFlego,Croatia,Renew Europe Group
+Vangelis MEIMARAKIS,https://twitter.com/v_meimarakis,@v_meimarakis,Greece,Group of the European People's Party (Christian Democrats)
 Vasile BLAGA,,,Romania,Group of the European People's Party (Christian Democrats)
 Vera TAX,https://twitter.com/Vera_Tax,@Vera_Tax,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Veronika VRECIONOVÁ,,,Czechia,European Conservatives and Reformists Group
-Véronique TRILLET-LENOIR,https://twitter.com/VTrillet_Lenoir ,@VTrillet_Lenoir ,France,Renew Europe Group
+Véronique TRILLET-LENOIR,https://twitter.com/VTrillet_Lenoir,@VTrillet_Lenoir,France,Renew Europe Group
 Viktor USPASKICH,https://twitter.com/ViktorUspaskich,@ViktorUspaskich,Lithuania,Renew Europe Group
 Vilija BLINKEVIČIŪTĖ,,,Lithuania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Ville NIINISTÖ,https://www.twitter.com/villeniinisto,@villeniinisto,Finland,Group of the Greens/European Free Alliance
@@ -743,5 +743,5 @@ Yana TOOM,https://twitter.com/yanatoom,@yanatoom,Estonia,Renew Europe Group
 Yannick JADOT,https://twitter.com/yjadot,@yjadot,France,Group of the Greens/European Free Alliance
 Younous OMARJEE,https://twitter.com/younousomarjee,@younousomarjee,France,Confederal Group of the European United Left - Nordic Green Left
 Zbigniew KUŹMIUK,https://twitter.com/zbigniewkuzmiuk,@zbigniewkuzmiuk,Poland,European Conservatives and Reformists Group
-Zdzisław KRASNODĘBSKI,https://twitter.com/ZdzKrasnodebski ,@ZdzKrasnodebski ,Poland,European Conservatives and Reformists Group
+Zdzisław KRASNODĘBSKI,https://twitter.com/ZdzKrasnodebski,@ZdzKrasnodebski,Poland,European Conservatives and Reformists Group
 Željana ZOVKO,https://twitter.com/ZovkoEU,@ZovkoEU,Croatia,Group of the European People's Party (Christian Democrats)

--- a/meps_full_list_with_twitter_accounts.csv
+++ b/meps_full_list_with_twitter_accounts.csv
@@ -1,6 +1,6 @@
 NAME,TWITTER_URL,SCREEN_NAME,NATIONALITY,GROUP
 Abir AL SAHLANI,https://twitter.com/abiralsahlani,@abiralsahlani,Sweden,Renew Europe Group
-Adam BIELAN,http://twitter.com/AdamBielan,@AdamBielan,Poland,European Conservatives and Reformists Group
+Adam BIELAN,https://twitter.com/AdamBielan,@AdamBielan,Poland,European Conservatives and Reformists Group
 Adam JARUBAS,https://twitter.com/JarubasAdam,@JarubasAdam,Poland,Group of the European People's Party (Christian Democrats)
 Ádám KÓSA,https://twitter.com/adamkosamep,@adamkosamep,Hungary,Group of the European People's Party (Christian Democrats)
 Adina-Ioana VĂLEAN,https://twitter.com/AdinaValean,@AdinaValean,Romania,Group of the European People's Party (Christian Democrats)
@@ -12,7 +12,7 @@ Aileen McLEOD,https://twitter.com/AileenMcLeodSNP,@AileenMcLeodSNP,United Kingdo
 Aldo PATRICIELLO,https://twitter.com/PatricielloAldo,@PatricielloAldo,Italy,Group of the European People's Party (Christian Democrats)
 Alessandra BASSO,https://twitter.com/alebassoMEP,@alebassoMEP,Italy,Identity and Democracy Group
 Alessandra MORETTI,https://twitter.com/ale_moretti,@ale_moretti,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Alessandro PANZA,http://twitter.com/alepanzaoff,@alepanzaoff,Italy,Identity and Democracy Group
+Alessandro PANZA,https://twitter.com/alepanzaoff,@alepanzaoff,Italy,Identity and Democracy Group
 Alex AGIUS SALIBA,https://twitter.com/alexagiussaliba,@alexagiussaliba,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Alexander ALEXANDROV YORDANOV,,,Bulgaria,Group of the European People's Party (Christian Democrats)
 Alexander BERNHUBER,,,Austria,Group of the European People's Party (Christian Democrats)
@@ -20,15 +20,15 @@ Alexandr VONDRA,https://twitter.com/alexandrvondra,@alexandrvondra,Czechia,Europ
 Alexandra GEESE,https://twitter.com/alexandra_geese,@alexandra_geese,Germany,Group of the Greens/European Free Alliance
 Alexandra Lesley PHILLIPS,https://twitter.com/brexitalex,@brexitalex,United Kingdom,Non-attached Members
 Alexandra Louise Rosenfield PHILLIPS,https://twitter.com/alexforeurope,@alexforeurope,United Kingdom,Group of the Greens/European Free Alliance
-Alexandros GEORGOULIS,http://twitter.com/georgoulisalexi,@georgoulisalexi,Greece,Confederal Group of the European United Left - Nordic Green Left
+Alexandros GEORGOULIS,https://twitter.com/AlexisMep,@AlexisMep,Greece,Confederal Group of the European United Left - Nordic Green Left
 Alfred SANT,https://twitter.com/SantAlfred,@SantAlfred,Malta,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Alice KUHNKE,,,Sweden,Group of the Greens/European Free Alliance
 Alicia HOMS GINEL,https://twitter.com/aliciahoms,@aliciahoms,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Álvaro AMARO,,,Portugal,Group of the European People's Party (Christian Democrats)
-Alyn SMITH,https://twitter.com/AlynSmithMEP,@AlynSmithMEP,United Kingdom,Group of the Greens/European Free Alliance
+Alyn SMITH,https://twitter.com/AlynSmith,@AlynSmith,United Kingdom,Group of the Greens/European Free Alliance
 Andor DELI,https://twitter.com/andordeli,@andordeli,Hungary,Group of the European People's Party (Christian Democrats)
 András GYÜRK,,,Hungary,Group of the European People's Party (Christian Democrats)
-André ROUGÉ,https://twitter.com/RougAndr1,@/RougAndr1,France,Identity and Democracy Group
+André ROUGÉ,https://twitter.com/RougAndr1,@RougAndr1,France,Identity and Democracy Group
 Andrea BOCSKOR,https://twitter.com/AndreaBocskor,@AndreaBocskor,Hungary,Group of the European People's Party (Christian Democrats)
 Andrea CAROPPO,https://twitter.com/caroppo_andrea,@caroppo_andrea,Italy,Identity and Democracy Group
 Andrea COZZOLINO,https://twitter.com/cozzolino62,@cozzolino62,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -36,7 +36,7 @@ Andreas GLÜCK,https://twitter.com/Andi_Glueck,@Andi_Glueck,Germany,Renew Europe
 Andreas SCHIEDER,https://twitter.com/schieder,@schieder,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Andreas SCHWAB,https://twitter.com/Andreas_Schwab,@Andreas_Schwab,Germany,Group of the European People's Party (Christian Democrats)
 Andrew ENGLAND KERR,https://twitter.com/englandkerrmep,@englandkerrmep,United Kingdom,Non-attached Members
-Andrey KOVATCHEV,http://twitter.com/andreykovatchev,@andreykovatchev,Bulgaria,Group of the European People's Party (Christian Democrats)
+Andrey KOVATCHEV,https://twitter.com/andreykovatchev,@andreykovatchev,Bulgaria,Group of the European People's Party (Christian Democrats)
 Andrey NOVAKOV,https://twitter.com/andreynovakov,@andreynovakov,Bulgaria,Group of the European People's Party (Christian Democrats)
 Andrey SLABAKOV,,,Bulgaria,European Conservatives and Reformists Group
 Andris AMERIKS,https://twitter.com/AndrisAmeriks,@AndrisAmeriks,Latvia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -52,23 +52,23 @@ Anja HAZEKAMP,https://twitter.com/anjahazekamp,@anjahazekamp,Netherlands,Confede
 Ann WIDDECOMBE,,,United Kingdom,Non-attached Members
 Anna BONFRISCO,,,Italy,Identity and Democracy Group
 Anna CAVAZZINI,https://twitter.com/anna_cavazzini,@anna_cavazzini,Germany,Group of the Greens/European Free Alliance
-Anna DEPARNAY-GRUNENBERG,https://twitter.com/candidate_verte,@candidate_verte,Germany,Group of the Greens/European Free Alliance
+Anna DEPARNAY-GRUNENBERG,https://twitter.com/AnnaDeparnay,@AnnaDeparnay,Germany,Group of the Greens/European Free Alliance
 Anna FOTYGA,https://twitter.com/AnnaFotyga_PE,@AnnaFotyga_PE,Poland,European Conservatives and Reformists Group
 Anna Julia DONÁTH,https://twitter.com/donath_anna,@donath_anna,Hungary,Renew Europe Group
-Anna ZALEWSKA,,,Poland,European Conservatives and Reformists Group
+Anna ZALEWSKA,https://twitter.com/_AnnaZalewska,@_AnnaZalewska,Poland,European Conservatives and Reformists Group
 Anna-Michelle ASIMAKOPOULOU,https://twitter.com/AnnaAsimakopoul,@AnnaAsimakopoul,Greece,Group of the European People's Party (Christian Democrats)
-Annalisa TARDINO,http://twitter.com/tardinoannalisa,@tardinoannalisa,Italy,Identity and Democracy Group
+Annalisa TARDINO,https://twitter.com/tardinoannalisa,@tardinoannalisa,Italy,Identity and Democracy Group
 Anne SANDER,https://twitter.com/ASanderMEP,@ASanderMEP,France,Group of the European People's Party (Christian Democrats)
 Anne-Sophie PELLETIER,https://twitter.com/ASPelletier,@ASPelletier,France,Confederal Group of the European United Left - Nordic Green Left
 Annie SCHREIJER-PIERIK,https://twitter.com/AnnieSchreijer,@AnnieSchreijer,Netherlands,Group of the European People's Party (Christian Democrats)
 Annika BRUNA,,,France,Identity and Democracy Group
-Annunziata Mary REES-MOGG,,,United Kingdom,Non-attached Members
+Annunziata Mary REES-MOGG,https://twitter.com/zatzi,@zatzi,United Kingdom,Non-attached Members
 Anthea McINTYRE,https://twitter.com/anthea_mcintyre,@anthea_mcintyre,United Kingdom,European Conservatives and Reformists Group
 Antonio LÓPEZ-ISTÚRIZ WHITE,https://twitter.com/TonoEPP,@TonoEPP,Spain,Group of the European People's Party (Christian Democrats)
 Antonio Maria RINALDI,https://twitter.com/Rinaldi_euro,@Rinaldi_euro,Italy,Identity and Democracy Group
 Antonio TAJANI,https://twitter.com/Antonio_Tajani,@Antonio_Tajani,Italy,Group of the European People's Party (Christian Democrats)
 Antonius MANDERS,,,Netherlands,Group of the European People's Party (Christian Democrats)
-Antony HOOK,https://twitter.com/antonyhook,@antonyhook,United Kingdom,Renew Europe Group
+Antony HOOK,https://twitter.com/AntonyHookMEP,@AntonyHookMEP,United Kingdom,Renew Europe Group
 Arba KOKALARI,https://twitter.com/arbakokalari,@arbakokalari,Sweden,Group of the European People's Party (Christian Democrats)
 Arnaud DANJEAN,https://twitter.com/ArnaudDanjean,@ArnaudDanjean,France,Group of the European People's Party (Christian Democrats)
 Asger CHRISTENSEN,https://twitter.com/AsgerChristens2,@AsgerChristens2,Denmark,Renew Europe Group
@@ -80,7 +80,7 @@ Attila ARA-KOVÁCS,https://twitter.com/AraKovacs,@AraKovacs,Hungary,Group of the
 Aurelia BEIGNEUX,https://twitter.com/AureliaBeigneux,@AureliaBeigneux,France,Identity and Democracy Group
 Aurore LALUCQ,https://twitter.com/AuroreLalucq,@AuroreLalucq,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Aušra MALDEIKIENĖ,https://twitter.com/maldeikiene,@maldeikiene,Lithuania,Group of the European People's Party (Christian Democrats)
-Axel VOSS,http://twitter.com/AxelVossMdEP,@AxelVossMdEP,Germany,Group of the European People's Party (Christian Democrats)
+Axel VOSS,https://twitter.com/AxelVossMdEP,@AxelVossMdEP,Germany,Group of the European People's Party (Christian Democrats)
 Balázs HIDVÉGHI,,,Hungary,Group of the European People's Party (Christian Democrats)
 Barbara Ann GIBSON,https://twitter.com/Barb_G,@Barb_G,United Kingdom,Renew Europe Group
 Barbara THALER,https://twitter.com/thalerbarbara,@thalerbarbara,Austria,Group of the European People's Party (Christian Democrats)
@@ -109,7 +109,7 @@ Brian MONTEITH,https://twitter.com/TheBluetrot,@TheBluetrot,United Kingdom,Non-a
 Brice HORTEFEUX,https://twitter.com/BriceHortefeux,@BriceHortefeux,France,Group of the European People's Party (Christian Democrats)
 Bronis ROPĖ,https://twitter.com/BronisRopeLT,@BronisRopeLT,Lithuania,Group of the Greens/European Free Alliance
 Carlo CALENDA,https://twitter.com/CarloCalenda,@CarloCalenda,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Carlo FIDANZA,http://twitter.com/fidanzacarlo,@fidanzacarlo,Italy,European Conservatives and Reformists Group
+Carlo FIDANZA,https://twitter.com/fidanzacarlo,@fidanzacarlo,Italy,European Conservatives and Reformists Group
 Carlos ZORRINHO,https://twitter.com/czorrinho,@czorrinho,Portugal,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Carmen AVRAM,https://twitter.com/carmenavram,@carmenavram,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Caroline NAGTEGAAL,https://twitter.com/c_nagtegaal,@c_nagtegaal,Netherlands,Renew Europe Group
@@ -119,12 +119,12 @@ Caterina CHINNICI,https://twitter.com/CaterinaChinnic,@CaterinaChinnic,Italy,Gro
 Catherine BEARDER,https://twitter.com/catherinemep,@catherinemep,United Kingdom,Renew Europe Group
 Catherine CHABAUD,https://twitter.com/CathChabaud,@CathChabaud,France,Renew Europe Group
 Catherine GRISET,https://twitter.com/GrisetCatherine,@GrisetCatherine,France,Identity and Democracy Group
-Catherine ROWETT,http://twitter.com/catherinerowett,@catherinerowett,United Kingdom,Group of the Greens/European Free Alliance
+Catherine ROWETT,https://twitter.com/catherinerowett,@catherinerowett,United Kingdom,Group of the Greens/European Free Alliance
 César LUENA,https://twitter.com/cesarluena,@cesarluena,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Charles GOERENS,https://twitter.com/CharlesGoerens,@CharlesGoerens,Luxembourg,Renew Europe Group
 Charlie WEIMERS,https://twitter.com/weimers,@weimers,Sweden,European Conservatives and Reformists Group
 Chiara GEMMA,https://twitter.com/chgemma68,@chgemma68,Italy,Non-attached Members
-Chris DAVIES,https://twitter.com/ChrisDaviesLD,@ChrisDaviesLD,United Kingdom,Renew Europe Group
+Chris DAVIES,https://twitter.com/ChrisDaviesEU,@ChrisDaviesEU,United Kingdom,Renew Europe Group
 Christel SCHALDEMOSE,https://twitter.com/SchaldemoseMEP,@SchaldemoseMEP,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Christian ALLARD,https://twitter.com/christia_allard,@christia_allard,United Kingdom,Group of the Greens/European Free Alliance
 Christian EHLER,,,Germany,Group of the European People's Party (Christian Democrats)
@@ -159,7 +159,7 @@ Dacian CIOLOS,https://twitter.com/CiolosDacian,@CiolosDacian,Romania,Renew Europ
 Damian BOESELAGER,https://twitter.com/d_boeselager,@d_boeselager,Germany,Group of the Greens/European Free Alliance
 Damien CARÊME,https://twitter.com/damiencareme,@damiencareme,France,Group of the Greens/European Free Alliance
 Dan NICA,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Dan-Ștefan MOTREANU,,,Romania,Group of the European People's Party (Christian Democrats)
+Dan-Ștefan MOTREANU,https://twitter.com/Dan_Motreanu,@Dan_Motreanu,Romania,Group of the European People's Party (Christian Democrats)
 Daniel BUDA,https://twitter.com/MEPDanielBuda,@MEPDanielBuda,Romania,Group of the European People's Party (Christian Democrats)
 Daniel CASPARY,https://twitter.com/caspary,@caspary,Germany,Group of the European People's Party (Christian Democrats)
 Daniel FREUND,https://twitter.com/daniel_freund,@daniel_freund,Germany,Group of the Greens/European Free Alliance
@@ -194,7 +194,7 @@ Edina TÓTH,https://twitter.com/toth_edina,@toth_edina,Hungary,Group of the Euro
 Eero HEINÄLUOMA,https://twitter.com/EeroHeinaluoma,@EeroHeinaluoma,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Eider GARDIAZABAL RUBIAL,https://twitter.com/EGardiazabal,@EGardiazabal,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Elena KOUNTOURA,https://twitter.com/ElenaKountoura,@ElenaKountoura,Greece,Confederal Group of the European United Left - Nordic Green Left
-Elena LIZZI,http://twitter.com/elenalizzi,@elenalizzi,Italy,Identity and Democracy Group
+Elena LIZZI,https://twitter.com/elenalizzi,@elenalizzi,Italy,Identity and Democracy Group
 Elena YONCHEVA,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Eleonora EVI,https://twitter.com/eleonoraevi,@eleonoraevi,Italy,Non-attached Members
 Elisabetta GUALMINI,https://twitter.com/gualminielisa,@gualminielisa,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -209,7 +209,7 @@ Emmanouil FRAGKOS,https://twitter.com/manolis_fragkos ,@manolis_fragkos,Greece,E
 Emmanuel MAUREL,https://twitter.com/emmanuelmaurel,@emmanuelmaurel,France,Confederal Group of the European United Left - Nordic Green Left
 Engin EROGLU,https://twitter.com/EnginEroglu_FW,@EnginEroglu_FW,Germany,Renew Europe Group
 Enikő GYŐRI,https://twitter.com/EGyori,@EGyori,Hungary,Group of the European People's Party (Christian Democrats)
-Eric ANDRIEU,https://twitter.com/Eric_Andrieu,@Eric_Andrieu,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Eric ANDRIEU,https://twitter.com/EricAndrieuEU,@EricAndrieuEU,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Erik BERGKVIST,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Erik MARQUARDT,https://twitter.com/erikmarquardt,@erikmarquardt,Germany,Group of the Greens/European Free Alliance
 Ernest URTASUN,https://twitter.com/ernesturtasun,@ernesturtasun,Spain,Group of the Greens/European Free Alliance
@@ -236,12 +236,12 @@ Francesca DONATO,https://twitter.com/ladyonorato,@ladyonorato,Italy,Identity and
 Francisco GUERREIRO,https://twitter.com/FGuerreiroMEP,@FGuerreiroMEP,Portugal,Group of the Greens/European Free Alliance
 Francisco José MILLÁN MON,https://twitter.com/PacoMillanMon,@PacoMillanMon,Spain,Group of the European People's Party (Christian Democrats)
 Franco ROBERTI,https://twitter.com/francorobertieu,@francorobertieu,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-François ALFONSI,https://twitter.com/F_Alfonsi,@/F_Alfonsi,France,Group of the Greens/European Free Alliance
+François ALFONSI,https://twitter.com/F_Alfonsi,@F_Alfonsi,France,Group of the Greens/European Free Alliance
 François-Xavier BELLAMY,https://twitter.com/fxbellamy,@fxbellamy,France,Group of the European People's Party (Christian Democrats)
-Frédérique RIES,http://twitter.com/Frederiqueries,@Frederiqueries,Belgium,Renew Europe Group
+Frédérique RIES,https://twitter.com/Frederiqueries,@Frederiqueries,Belgium,Renew Europe Group
 Fredrick FEDERLEY,https://twitter.com/federley,@federley,Sweden,Renew Europe Group
 Fulvio MARTUSCIELLO,https://twitter.com/fulviomartuscie,@fulviomartuscie,Italy,Group of the European People's Party (Christian Democrats)
-Gabriele BISCHOFF,,,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Gabriele BISCHOFF,https://twitter.com/gabischoff,@gabischoff,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Geert BOURGEOIS,https://twitter.com/GeertBourgeois,@GeertBourgeois,Belgium,European Conservatives and Reformists Group
 Geoffrey VAN ORDEN,https://twitter.com/GVOMEP,@GVOMEP,United Kingdom,European Conservatives and Reformists Group
 Geoffroy DIDIER,https://twitter.com/geoffroydidier,@geoffroydidier,France,Group of the European People's Party (Christian Democrats)
@@ -256,15 +256,15 @@ Gilles BOYER,https://twitter.com/gillesboyer,@gillesboyer,France,Renew Europe Gr
 Gilles LEBRETON,https://twitter.com/Gilles_Lebreton,@Gilles_Lebreton,France,Identity and Democracy Group
 Gina DOWDING,https://twitter.com/GinaDowdingMEP,@GinaDowdingMEP,United Kingdom,Group of the Greens/European Free Alliance
 Giorgos GEORGIOU,,,Cyprus,Confederal Group of the European United Left - Nordic Green Left
-Giuliano PISAPIA,http://twitter.com/giulianopisapia,@giulianopisapia,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Giuliano PISAPIA,https://twitter.com/giulianopisapia,@giulianopisapia,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Giuseppe FERRANDINO,https://twitter.com/giosiferrandino,@giosiferrandino,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Giuseppe MILAZZO,https://twitter.com/giuseppemilaz11,@giuseppemilaz11,Italy,Group of the European People's Party (Christian Democrats)
-Grace O'SULLIVAN,http://twitter.com/GraceOSllvn,@GraceOSllvn,Ireland,Group of the Greens/European Free Alliance
+Grace O'SULLIVAN,https://twitter.com/GraceOSllvn,@GraceOSllvn,Ireland,Group of the Greens/European Free Alliance
 Grzegorz TOBISZOWSKI,https://twitter.com/tobiszowski ,@tobiszowski ,Poland,European Conservatives and Reformists Group
 Guido REIL,https://twitter.com/GuidoReil ,@GuidoReil ,Germany,Identity and Democracy Group
 Gunnar Günter BECK,,,Germany,Identity and Democracy Group
 Günther SIDL,,,Austria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Guy VERHOFSTADT,http://twitter.com/GuyVerhofstadt,@GuyVerhofstadt,Belgium,Renew Europe Group
+Guy VERHOFSTADT,https://twitter.com/GuyVerhofstadt,@GuyVerhofstadt,Belgium,Renew Europe Group
 Gwendoline DELBOS-CORFIELD,https://twitter.com/GDelbosCorfield ,@GDelbosCorfield ,France,Group of the Greens/European Free Alliance
 György HÖLVÉNYI,https://twitter.com/HolvenyiGyorgy,@HolvenyiGyorgy,Hungary,Group of the European People's Party (Christian Democrats)
 Hannah NEUMANN,https://twitter.com/Hannah_LBerg,@Hannah_LBerg,Germany,Group of the Greens/European Free Alliance
@@ -272,7 +272,7 @@ Hannes HEIDE,https://twitter.com/HannesHeide,@HannesHeide,Austria,Group of the P
 Harald VILIMSKY,https://twitter.com/vilimsky ,@vilimsky ,Austria,Identity and Democracy Group
 Heidi HAUTALA,https://twitter.com/HeidiHautala ,@HeidiHautala ,Finland,Group of the Greens/European Free Alliance
 Heléne FRITZON,,,Sweden,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Hélène LAPORTE,http://twitter.com/HeleneLaporteRN,@HeleneLaporteRN,France,Identity and Democracy Group
+Hélène LAPORTE,https://twitter.com/HeleneLaporteRN,@HeleneLaporteRN,France,Identity and Democracy Group
 Helmut GEUKING,,,Germany,European Conservatives and Reformists Group
 Helmut SCHOLZ,https://twitter.com/HelmutScholzMEP ,@HelmutScholzMEP ,Germany,Confederal Group of the European United Left - Nordic Green Left
 Henna VIRKKUNEN,https://twitter.com/HennaVirkkunen,@HennaVirkkunen,Finland,Group of the European People's Party (Christian Democrats)
@@ -319,13 +319,13 @@ Jacek SARYUSZ-WOLSKI,https://twitter.com/JSaryuszWolski ,@JSaryuszWolski ,Poland
 Jackie JONES,https://twitter.com/JackieJonesWal1,@JackieJonesWal1,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Jadwiga WIŚNIEWSKA,https://twitter.com/j_wisniewska,@j_wisniewska,Poland,European Conservatives and Reformists Group
 Jake PUGH,https://twitter.com/jake_pugh ,@jake_pugh ,United Kingdom,Non-attached Members
-James Alexander GLANCY,,,United Kingdom,Non-attached Members
+James Alexander GLANCY,https://twitter.com/jaglancy,@jaglancy,United Kingdom,Non-attached Members
 James WELLS,https://twitter.com/jamesfwells,@jamesfwells,United Kingdom,Non-attached Members
 Jan HUITEMA,https://twitter.com/jhuitema,@jhuitema,Netherlands,Renew Europe Group
-Jan OLBRYCHT,http://twitter.com/JanOlbrycht,@JanOlbrycht,Poland,Group of the European People's Party (Christian Democrats)
+Jan OLBRYCHT,https://twitter.com/JanOlbrycht,@JanOlbrycht,Poland,Group of the European People's Party (Christian Democrats)
 Jan ZAHRADIL,https://twitter.com/ZahradilJan,@ZahradilJan,Czechia,European Conservatives and Reformists Group
 Jan-Christoph OETJEN,https://twitter.com/jcoetjen,@jcoetjen,Germany,Renew Europe Group
-Jane BROPHY,https://twitter.com/Jane_Brophy,@Jane_Brophy,United Kingdom,Renew Europe Group
+Jane BROPHY,https://twitter.com/JaneBrophyLD,@JaneBrophyLD,United Kingdom,Renew Europe Group
 Janina OCHOJSKA,https://twitter.com/JaninaOchojska,@JaninaOchojska,Poland,Group of the European People's Party (Christian Democrats)
 Janusz LEWANDOWSKI,https://twitter.com/J_Lewandowski,@J_Lewandowski,Poland,Group of the European People's Party (Christian Democrats)
 Jarosław DUDA,https://twitter.com/jaroslawduda,@jaroslawduda,Poland,Group of the European People's Party (Christian Democrats)
@@ -341,7 +341,7 @@ Jens GIESEKE,,,Germany,Group of the European People's Party (Christian Democrats
 Jérémy DECERLE,https://twitter.com/JDecerle ,@JDecerle ,France,Renew Europe Group
 Jeroen LENAERS,https://twitter.com/jeroen_lenaers,@jeroen_lenaers,Netherlands,Group of the European People's Party (Christian Democrats)
 Jérôme RIVIÈRE,https://twitter.com/jerome_riviere,@jerome_riviere,France,Identity and Democracy Group
-Jerzy BUZEK,http://twitter.com/JerzyBuzek,@JerzyBuzek,Poland,Group of the European People's Party (Christian Democrats)
+Jerzy BUZEK,https://twitter.com/JerzyBuzek,@JerzyBuzek,Poland,Group of the European People's Party (Christian Democrats)
 Jessica POLFJÄRD,https://twitter.com/jessicapolfjard ,@jessicapolfjard ,Sweden,Group of the European People's Party (Christian Democrats)
 Jessica STEGRUD,https://twitter.com/JessicaStegrud ,@JessicaStegrud ,Sweden,European Conservatives and Reformists Group
 Jill EVANS,https://twitter.com/JillEvansMEP,@JillEvansMEP,United Kingdom,Group of the Greens/European Free Alliance
@@ -364,7 +364,7 @@ Jordi CAÑAS,https://twitter.com/jordi_canyas,@jordi_canyas,Spain,Renew Europe G
 Jörg MEUTHEN,https://twitter.com/Joerg_Meuthen ,@Joerg_Meuthen ,Germany,Identity and Democracy Group
 Jorge BUXADÉ VILLALBA,https://twitter.com/jorgebuxade,@jorgebuxade,Spain,European Conservatives and Reformists Group
 Jörgen WARBORN,https://twitter.com/jorgenwarborn,@jorgenwarborn,Sweden,Group of the European People's Party (Christian Democrats)
-José GUSMÃO,http://www.twitter.com/joseggusmao,@joseggusmao,Portugal,Confederal Group of the European United Left - Nordic Green Left
+José GUSMÃO,https://www.twitter.com/joseggusmao,@joseggusmao,Portugal,Confederal Group of the European United Left - Nordic Green Left
 José Manuel FERNANDES,https://twitter.com/JMFernandesEU,@JMFernandesEU,Portugal,Group of the European People's Party (Christian Democrats)
 José Manuel GARCÍA-MARGALLO Y MARFIL,https://twitter.com/MargalloJm,@MargalloJm,Spain,Group of the European People's Party (Christian Democrats)
 José Ramón BAUZÁ DÍAZ,https://twitter.com/jrbauza,@jrbauza,Spain,Renew Europe Group
@@ -391,7 +391,7 @@ Katarina BARLEY,https://twitter.com/KATARINABARLEY,@KATARINABARLEY,Germany,Group
 Kateřina KONEČNÁ,https://twitter.com/Konecna_K ,@Konecna_K ,Czechia,Confederal Group of the European United Left - Nordic Green Left
 Kathleen VAN BREMPT,https://twitter.com/kvanbrempt ,@kvanbrempt ,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Kati PIRI,https://twitter.com/KatiPiri,@KatiPiri,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Katrin LANGENSIEPEN,https://twitter.com/katrinlangensie,@katrinlangensie,Germany,Group of the Greens/European Free Alliance
+Katrin LANGENSIEPEN,https://twitter.com/k_langensiepen,@k_langensiepen,Germany,Group of the Greens/European Free Alliance
 Kim VAN SPARRENTAK,https://twitter.com/kimvsparrentak,@kimvsparrentak,Netherlands,Group of the Greens/European Free Alliance
 Kinga GÁL,,,Hungary,Group of the European People's Party (Christian Democrats)
 Kira Marie PETER-HANSEN,https://twitter.com/kira_mph,@kira_mph,Denmark,Group of the Greens/European Free Alliance
@@ -423,7 +423,7 @@ Lina GALVEZ MUÑOZ,https://twitter.com/linagalvezmunoz,@linagalvezmunoz,Spain,Gr
 Liudas MAŽYLIS,,,Lithuania,Group of the European People's Party (Christian Democrats)
 Lívia JÁRÓKA,https://twitter.com/JarokaLivia ,@JarokaLivia ,Hungary,Group of the European People's Party (Christian Democrats)
 Ljudmila NOVAK,https://twitter.com/LjudmilaNovak ,@LjudmilaNovak ,Slovenia,Group of the European People's Party (Christian Democrats)
-Lorant-Gyorgy VINCZE,http://twitter.com/vinczelorant,@vinczelorant,Romania,Group of the European People's Party (Christian Democrats)
+Lorant-Gyorgy VINCZE,https://twitter.com/vinczelorant,@vinczelorant,Romania,Group of the European People's Party (Christian Democrats)
 Loucas FOURLAS,https://twitter.com/loucas_fourlas,@loucas_fourlas,Cyprus,Group of the European People's Party (Christian Democrats)
 Louis STEDMAN-BRYCE,https://twitter.com/lstedmanbryce,@lstedmanbryce,United Kingdom,Non-attached Members
 Lucia ĎURIŠ NICHOLSONOVÁ,https://twitter.com/LNicholsonova ,@LNicholsonova ,Slovakia,European Conservatives and Reformists Group
@@ -452,7 +452,7 @@ Manuel PIZARRO,https://twitter.com/MPizarroPorto ,@MPizarroPorto ,Portugal,Group
 Mara BIZZOTTO,https://twitter.com/marabizzotto ,@marabizzotto ,Italy,Identity and Democracy Group
 Marc BOTENGA,https://www.twitter.com/botengam,@botengam,Belgium,Confederal Group of the European United Left - Nordic Green Left
 Marc TARABELLA,https://twitter.com/marctarabella,@marctarabella,Belgium,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
-Marcel KOLAJA,http://twitter.com/Piratkolaja,@Piratkolaja,Czechia,Group of the Greens/European Free Alliance
+Marcel KOLAJA,https://twitter.com/PiratKolaja,@PiratKolaja,Czechia,Group of the Greens/European Free Alliance
 Marco CAMPOMENOSI,https://twitter.com/mcampomenosi,@mcampomenosi,Italy,Identity and Democracy Group
 Marco DREOSTO,https://twitter.com/MarcoDreosto ,@MarcoDreosto ,Italy,Identity and Democracy Group
 Marco ZANNI,https://twitter.com/Marcozanni86,@Marcozanni86,Italy,Identity and Democracy Group
@@ -470,13 +470,14 @@ María Soraya RODRÍGUEZ RAMOS,https://twitter.com/sorayarr_,@sorayarr_,Spain,Re
 Maria SPYRAKI,https://twitter.com/MariaSpyraki,@MariaSpyraki,Greece,Group of the European People's Party (Christian Democrats)
 Maria WALSH,https://twitter.com/mariawalsheu,@mariawalsheu,Ireland,Group of the European People's Party (Christian Democrats)
 Marian-Jean MARINESCU,https://twitter.com/MarianMarinescu ,@MarianMarinescu ,Romania,Group of the European People's Party (Christian Democrats)
+Marianne VIND,https://twitter.com/MarianneVind,@MarianneVind,Denmark,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Marie TOUSSAINT,https://twitter.com/marietouss1,@marietouss1,France,Group of the Greens/European Free Alliance
 Marie-Pierre VEDRENNE,https://twitter.com/mariepierrev,@mariepierrev,France,Renew Europe Group
 Marina KALJURAND,https://twitter.com/MarinaKaljurand ,@MarinaKaljurand ,Estonia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Mario FURORE,https://twitter.com/MarioFurore,@MarioFurore,Italy,Non-attached Members
 Marion WALSMANN,https://twitter.com/marionwalsmann,@marionwalsmann,Germany,Group of the European People's Party (Christian Democrats)
 Marisa MATIAS,https://twitter.com/mmatias_,@mmatias_,Portugal,Confederal Group of the European United Left - Nordic Green Left
-Markéta GREGOROVÁ,http://twitter.com/MarketkaG,@MarketkaG,Czechia,Group of the Greens/European Free Alliance
+Markéta GREGOROVÁ,https://twitter.com/MarketkaG,@MarketkaG,Czechia,Group of the Greens/European Free Alliance
 Markus BUCHHEIT,https://twitter.com/BuchheitMarkus ,@BuchheitMarkus ,Germany,Identity and Democracy Group
 Markus FERBER,https://twitter.com/MarkusFerber,@MarkusFerber,Germany,Group of the European People's Party (Christian Democrats)
 Markus PIEPER,https://twitter.com/markuspiepermep,@markuspiepermep,Germany,Group of the European People's Party (Christian Democrats)
@@ -507,11 +508,11 @@ Mazaly AGUILAR,https://twitter.com/MazalyAguilar ,@MazalyAguilar ,Spain,European
 Miapetra KUMPULA-NATRI,https://twitter.com/miapetrakumpula,@miapetrakumpula,Finland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Michael BLOSS,https://twitter.com/michabl,@michabl,Germany,Group of the Greens/European Free Alliance
 Michael GAHLER,https://twitter.com/michaelgahler ,@michaelgahler ,Germany,Group of the European People's Party (Christian Democrats)
-Michael HEAVER,http://twitter.com/michael_heaver,@michael_heaver,United Kingdom,Non-attached Members
+Michael HEAVER,https://twitter.com/michael_heaver,@michael_heaver,United Kingdom,Non-attached Members
 Michaela ŠOJDROVÁ,https://twitter.com/msojdrova ,@msojdrova ,Czechia,Group of the European People's Party (Christian Democrats)
 Michal ŠIMEČKA,,,Slovakia,Renew Europe Group
 Michal WIEZIK,,,Slovakia,Group of the European People's Party (Christian Democrats)
-Michèle RIVASI,https://twitter.com/MicheleRivasi ,,France,Group of the Greens/European Free Alliance
+Michèle RIVASI,https://twitter.com/MicheleRivasi ,@MicheleRivasi,France,Group of the Greens/European Free Alliance
 Mick WALLACE,https://twitter.com/wallacemick,@wallacemick,Ireland,Confederal Group of the European United Left - Nordic Green Left
 Miguel URBÁN CRESPO,https://twitter.com/MiguelUrban,@MiguelUrban,Spain,Confederal Group of the European United Left - Nordic Green Left
 Mihai TUDOSE,,,Romania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -532,7 +533,7 @@ Monika BEŇOVÁ,https://twitter.com/monika_benova ,@monika_benova ,Slovakia,Grou
 Monika HOHLMEIER,https://twitter.com/MHohlmeier ,@MHohlmeier ,Germany,Group of the European People's Party (Christian Democrats)
 Monika VANA,https://twitter.com/MonikaVana ,@MonikaVana ,Austria,Group of the Greens/European Free Alliance
 Moritz KÖRNER,https://twitter.com/moritzkoerner,@moritzkoerner,Germany,Renew Europe Group
-Morten LØKKEGAARD,http://twitter.com/loekkegaard_mep,@loekkegaard_mep,Denmark,Renew Europe Group
+Morten LØKKEGAARD,https://twitter.com/loekkegaard_mep,@loekkegaard_mep,Denmark,Renew Europe Group
 Morten PETERSEN,https://twitter.com/mortenhelveg,@mortenhelveg,Denmark,Renew Europe Group
 Mounir SATOURI,https://twitter.com/mounirsatouri,@mounirsatouri,France,Group of the Greens/European Free Alliance
 Nacho SÁNCHEZ AMOR,https://twitter.com/NachoSAmor,@NachoSAmor,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -540,12 +541,13 @@ Nadine MORANO,https://twitter.com/nadine__morano,@nadine__morano,France,Group of
 Naomi LONG,https://twitter.com/naomi_long,@naomi_long,United Kingdom,Renew Europe Group
 Nathalie COLIN-OESTERLÉ,https://twitter.com/ncolin_oesterle ,@ncolin_oesterle ,France,Group of the European People's Party (Christian Democrats)
 Nathalie LOISEAU,https://twitter.com/NathalieLoiseau ,@NathalieLoiseau ,France,Renew Europe Group
-Nathan GILL,http://www.twitter.com/NathanGillMEP,@NathanGillMEP,United Kingdom,Non-attached Members
+Nathan GILL,https://www.twitter.com/NathanGillMEP,@NathanGillMEP,United Kingdom,Non-attached Members
 Neena GILL,https://twitter.com/NeenaGmep,@NeenaGmep,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Niclas HERBST,,,Germany,Group of the European People's Party (Christian Democrats)
 Nico SEMSROTT,https://www.twitter.com/nicosemsrott,@nicosemsrott,Germany,Group of the Greens/European Free Alliance
 Nicola BEER,https://twitter.com/nicolabeerfdp,@nicolabeerfdp,Germany,Renew Europe Group
-Nicola PROCACCINI,,,Italy,European Conservatives and Reformists Group
+Nicola DANTI,https://twitter.com/DantiNicola,@DantiNicola,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Nicola PROCACCINI,https://twitter.com/nprocaccini,@Nprocaccini,Italy,European Conservatives and Reformists Group
 Nicolae ȘTEFĂNUȚA,https://twitter.com/nicustefanuta,@nicustefanuta,Romania,Renew Europe Group
 Nicolas BAY,https://twitter.com/NicolasBay_,@NicolasBay_,France,Identity and Democracy Group
 Nicolás GONZALEZ CASARES,https://twitter.com/nicogoncas ,@nicogoncas ,Spain,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -564,13 +566,13 @@ Norbert NEUSER,,,Germany,Group of the Progressive Alliance of Socialists and Dem
 Nosheena MOBARIK Baroness,https://twitter.com/NosheenaMobarik,@NosheenaMobarik,United Kingdom,European Conservatives and Reformists Group
 Nuno MELO,https://twitter.com/NunoMeloCDS ,@NunoMeloCDS ,Portugal,Group of the European People's Party (Christian Democrats)
 Olivier CHASTEL,https://twitter.com/OChastel ,@OChastel ,Belgium,Renew Europe Group
-Ondřej KNOTEK,,,Czechia,Renew Europe Group
-Ondřej KOVAŘÍK,,,Czechia,Renew Europe Group
+Ondřej KNOTEK,https://twitter.com/KnotekOndrej,@KnotekOndrej,Czechia,Renew Europe Group
+Ondřej KOVAŘÍK,https://twitter.com/OKovarikMEP,@OkovarikMEP,Czechia,Renew Europe Group
 Oscar LANCINI,https://twitter.com/doscarlancini,@doscarlancini,Italy,Identity and Democracy Group
-Othmar KARAS,https://twitter.com/othmar_karas ,,Austria,Group of the European People's Party (Christian Democrats)
+Othmar KARAS,https://twitter.com/othmar_karas ,@othmar_karas,Austria,Group of the European People's Party (Christian Democrats)
 Özlem DEMIREL,https://twitter.com/oezlemademirel,@oezlemademirel,Germany,Confederal Group of the European United Left - Nordic Green Left
 Pablo ARIAS ECHEVERRÍA,,,Spain,Group of the European People's Party (Christian Democrats)
-Paolo BORCHIA,http://twitter.com/paoloborchia,@paoloborchia,Italy,Identity and Democracy Group
+Paolo BORCHIA,https://twitter.com/paoloborchia,@paoloborchia,Italy,Identity and Democracy Group
 Paolo DE CASTRO,https://twitter.com/paolodecastro,@paolodecastro,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pär HOLMGREN,https://twitter.com/parholmgren,@parholmgren,Sweden,Group of the Greens/European Free Alliance
 Pascal ARIMONT,https://twitter.com/pascal_arimont ,@pascal_arimont ,Belgium,Group of the European People's Party (Christian Democrats)
@@ -587,11 +589,10 @@ Pernando BARRENA ARZA,https://twitter.com/pernandobarrena,@pernandobarrena,Spain
 Pernille WEISS,https://twitter.com/WeissPernille,@WeissPernille,Denmark,Group of the European People's Party (Christian Democrats)
 Petar VITANOV,,,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Peter JAHR,https://twitter.com/peter_jahr,@peter_jahr,Germany,Group of the European People's Party (Christian Democrats)
-Peter KOFOD,https://twitter.com/KofodPeter ,@KofodPeter ,Denmark,Identity and Democracy Group
-Peter LIESE,http://twitter.com/peterliese,@peterliese,Germany,Group of the European People's Party (Christian Democrats)
+Peter LIESE,https://twitter.com/peterliese,@peterliese,Germany,Group of the European People's Party (Christian Democrats)
 Peter LUNDGREN,,,Sweden,European Conservatives and Reformists Group
 Peter POLLÁK,https://twitter.com/Peter_Pollak ,@Peter_Pollak ,Slovakia,Group of the European People's Party (Christian Democrats)
-Peter van DALEN,http://twitter.com/petervdalen,@petervdalen,Netherlands,Group of the European People's Party (Christian Democrats)
+Peter van DALEN,https://twitter.com/petervdalen,@petervdalen,Netherlands,Group of the European People's Party (Christian Democrats)
 Petra DE SUTTER,https://twitter.com/pdsutter,@pdsutter,Belgium,Group of the Greens/European Free Alliance
 Petra KAMMEREVERT,,,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Petras AUŠTREVIČIUS,https://twitter.com/petras_petras,@petras_petras,Lithuania,Renew Europe Group
@@ -603,16 +604,16 @@ Philippe OLIVIER,https://twitter.com/PhOlivierRN ,@PhOlivierRN ,France,Identity 
 Pierfrancesco MAJORINO,https://twitter.com/pfmajorino,@pfmajorino,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Piernicola PEDICINI,https://twitter.com/PediciniM5S,@PediciniM5S,Italy,Non-attached Members
 Pierre KARLESKIND,https://twitter.com/Pierre_Ka ,@Pierre_Ka ,France,Renew Europe Group
-Pierre LARROUTUROU,http://twitter.com/larrouturou,@larrouturou,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Pierre LARROUTUROU,https://twitter.com/larrouturou,@larrouturou,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pierrette Gabrielle HERZBERGER-FOFANA,,,Germany,Group of the Greens/European Free Alliance
 Pietro BARTOLO,https://twitter.com/bartolopietro1,@bartolopietro1,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Pietro FIOCCHI,https://twitter.com/FiocchiPietro,@FiocchiPietro,Italy,European Conservatives and Reformists Group
-Pilar del CASTILLO VERA,http://twitter.com/delcastillop,@delcastillop,Spain,Group of the European People's Party (Christian Democrats)
+Pilar del CASTILLO VERA,https://twitter.com/delcastillop,@delcastillop,Spain,Group of the European People's Party (Christian Democrats)
 Pina PICIERNO,https://twitter.com/pinapic,@pinapic,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Predrag Fred MATIĆ,https://twitter.com/fred_matic,@fred_matic,Croatia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Radan KANEV,https://twitter.com/rmkanev ,@rmkanev ,Bulgaria,Group of the European People's Party (Christian Democrats)
 Radka MAXOVÁ,https://twitter.com/radkamaxova ,@radkamaxova ,Czechia,Renew Europe Group
-Radosław SIKORSKI,https://twitter.com/radeksikorski,@radeksikorski,Poland,Group of the European People's Party (Christian Democrats)
+Radosław SIKORSKI,https://twitter.com/sikorskiradek,@sikorskiradek,Poland,Group of the European People's Party (Christian Democrats)
 Raffaele FITTO,https://twitter.com/raffaelefitto,@raffaelefitto,Italy,European Conservatives and Reformists Group
 Raffaele STANCANELLI,https://twitter.com/r_stancanelli ,@r_stancanelli ,Italy,European Conservatives and Reformists Group
 Rainer WIELAND,,,Germany,Group of the European People's Party (Christian Democrats)
@@ -630,7 +631,6 @@ Robert HAJŠEL,https://twitter.com/RobertHajsel,@RobertHajsel,Slovakia,Group of 
 Robert ROOS,https://twitter.com/rob_roos,@rob_roos,Netherlands,European Conservatives and Reformists Group
 Robert ROWLAND,https://twitter.com/RowlandBrexitSE,@RowlandBrexitSE,United Kingdom,Non-attached Members
 Roberta METSOLA,https://twitter.com/RobertaMetsola,@RobertaMetsola,Malta,Group of the European People's Party (Christian Democrats)
-Roberto GUALTIERI,http://twitter.com/gualtierieurope,@gualtierieurope,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Roberts ZĪLE,https://twitter.com/robertszile ,@robertszile ,Latvia,European Conservatives and Reformists Group
 Roman HAIDER,,,Austria,Identity and Democracy Group
 Romana TOMC,https://twitter.com/RomanaTomc,@RomanaTomc,Slovenia,Group of the European People's Party (Christian Democrats)
@@ -656,7 +656,7 @@ Sara CERDAS,https://twitter.com/sara_saracerdas,@sara_saracerdas,Portugal,Group 
 Sara SKYTTEDAL,https://twitter.com/skyttedal,@skyttedal,Sweden,Group of the European People's Party (Christian Democrats)
 Sarah WIENER,,,Austria,Group of the Greens/European Free Alliance
 Saskia BRICMONT,https://twitter.com/bricmontsaskia,@bricmontsaskia,Belgium,Group of the Greens/European Free Alliance
-Scott AINSLIE,https://twitter.com/scottjainslie,@scottjainslie,United Kingdom,Group of the Greens/European Free Alliance
+Scott AINSLIE,https://twitter.com/ScottMEPLondon,@ScottMEPLondon,United Kingdom,Group of the Greens/European Free Alliance
 Seán KELLY,https://twitter.com/SeanKellyMEP ,@SeanKellyMEP ,Ireland,Group of the European People's Party (Christian Democrats)
 Seb DANCE,https://twitter.com/SebDance,@SebDance,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sergei STANISHEV,https://twitter.com/SergeiStanishev,@SergeiStanishev,Bulgaria,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
@@ -670,7 +670,7 @@ Silvio BERLUSCONI,https://twitter.com/berlusconi ,@berlusconi ,Italy,Group of th
 Simona BALDASSARRE,https://twitter.com/SR_Baldassarre ,@SR_Baldassarre ,Italy,Identity and Democracy Group
 Simona BONAFÈ,https://twitter.com/simonabonafe,@simonabonafe,Italy,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Simone SCHMIEDTBAUER,,,Austria,Group of the European People's Party (Christian Democrats)
-Sira REGO,http://twitter.com/SIRAREGO,@SIRAREGO,Spain,Confederal Group of the European United Left - Nordic Green Left
+Sira REGO,https://twitter.com/SIRAREGO,@SIRAREGO,Spain,Confederal Group of the European United Left - Nordic Green Left
 Sirpa PIETIKÄINEN,https://twitter.com/spietikainen,@spietikainen,Finland,Group of the European People's Party (Christian Democrats)
 Ska KELLER,https://twitter.com/SkaKeller,@SkaKeller,Germany,Group of the Greens/European Free Alliance
 Sophia in 't VELD,https://twitter.com/SophieintVeld,@SophieintVeld,Netherlands,Renew Europe Group
@@ -696,12 +696,12 @@ Sylvie BRUNET,https://twitter.com/syl_brunet,@syl_brunet,France,Renew Europe Gro
 Sylvie GUILLAUME,https://twitter.com/sylvieguillaume ,@sylvieguillaume ,France,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Sylwia SPUREK,https://twitter.com/sylwiaspurek,@sylwiaspurek,Poland,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tamás DEUTSCH,https://twitter.com/dajcstomi,@dajcstomi,Hungary,Group of the European People's Party (Christian Democrats)
-Tanja FAJON,http://twitter.com/tfajon,@tfajon,Slovenia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Tanja FAJON,https://twitter.com/tfajon,@tfajon,Slovenia,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tatjana ŽDANOKA,https://twitter.com/Tatjana_Zdanoka,@Tatjana_Zdanoka,Latvia,Group of the Greens/European Free Alliance
 Terry REINTKE,https://twitter.com/TerryReintke,@TerryReintke,Germany,Group of the Greens/European Free Alliance
 Teuvo HAKKARAINEN,,,Finland,Identity and Democracy Group
 Theodoros ZAGORAKIS,,,Greece,Group of the European People's Party (Christian Democrats)
-Theresa GRIFFIN,https://twitter.com/TheresaG_EU,@TheresaG_EU,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Theresa GRIFFIN,https://twitter.com/TheresaMEP,@TheresaMEP,United Kingdom,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Thierry MARIANI,https://twitter.com/thierrymariani,@thierrymariani,France,Identity and Democracy Group
 Tiemo WÖLKEN,https://twitter.com/woelken,@woelken,Germany,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Tilly METZ,,,Luxembourg,Group of the Greens/European Free Alliance
@@ -710,7 +710,7 @@ Tiziana BEGHIN,https://twitter.com/beghin_t,@beghin_t,Italy,Non-attached Members
 Tom BERENDSEN,https://twitter.com/tbwberendsen ,@tbwberendsen ,Netherlands,Group of the European People's Party (Christian Democrats)
 Tom VANDENDRIESSCHE,https://twitter.com/TomVandendriess ,@TomVandendriess ,Belgium,Identity and Democracy Group
 Tomas TOBÉ,https://twitter.com/tomastobe ,@tomastobe ,Sweden,Group of the European People's Party (Christian Democrats)
-Tomáš ZDECHOVSKÝ,https://twitter.com/TomZdechovsky,@TomZdechovsky,Czechia,Group of the European People's Party (Christian Democrats)
+Tomáš ZDECHOVSKÝ,https://twitter.com/TomZdechovskyEP,@TomZdechovskyEP,Czechia,Group of the European People's Party (Christian Democrats)
 Tomasz FRANKOWSKI,https://twitter.com/TFrankowski21 ,@TFrankowski21 ,Poland,Group of the European People's Party (Christian Democrats)
 Tomasz Piotr PORĘBA,https://twitter.com/TomaszPoreba ,@TomaszPoreba ,Poland,European Conservatives and Reformists Group
 Tomislav SOKOL,https://twitter.com/TomislavSokol ,@TomislavSokol ,Croatia,Group of the European People's Party (Christian Democrats)
@@ -727,10 +727,10 @@ Valerie HAYER,https://twitter.com/valeriehayer,@valeriehayer,France,Renew Europe
 Valter FLEGO,https://twitter.com/ValterFlego ,@ValterFlego ,Croatia,Renew Europe Group
 Vangelis MEIMARAKIS,https://twitter.com/v_meimarakis ,@v_meimarakis ,Greece,Group of the European People's Party (Christian Democrats)
 Vasile BLAGA,,,Romania,Group of the European People's Party (Christian Democrats)
-Vera TAX,,,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+Vera TAX,https://twitter.com/Vera_Tax,@Vera_Tax,Netherlands,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Veronika VRECIONOVÁ,,,Czechia,European Conservatives and Reformists Group
 Véronique TRILLET-LENOIR,https://twitter.com/VTrillet_Lenoir ,@VTrillet_Lenoir ,France,Renew Europe Group
-Viktor USPASKICH,http://twitter.com/ViktorUspaskich,@ViktorUspaskich,Lithuania,Renew Europe Group
+Viktor USPASKICH,https://twitter.com/ViktorUspaskich,@ViktorUspaskich,Lithuania,Renew Europe Group
 Vilija BLINKEVIČIŪTĖ,,,Lithuania,Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 Ville NIINISTÖ,https://www.twitter.com/villeniinisto,@villeniinisto,Finland,Group of the Greens/European Free Alliance
 Viola VON CRAMON-TAUBADEL,https://twitter.com/violavoncramon,@violavoncramon,Germany,Group of the Greens/European Free Alliance
@@ -745,4 +745,3 @@ Younous OMARJEE,https://twitter.com/younousomarjee,@younousomarjee,France,Confed
 Zbigniew KUŹMIUK,https://twitter.com/zbigniewkuzmiuk,@zbigniewkuzmiuk,Poland,European Conservatives and Reformists Group
 Zdzisław KRASNODĘBSKI,https://twitter.com/ZdzKrasnodebski ,@ZdzKrasnodebski ,Poland,European Conservatives and Reformists Group
 Željana ZOVKO,https://twitter.com/ZovkoEU,@ZovkoEU,Croatia,Group of the European People's Party (Christian Democrats)
-


### PR DESCRIPTION
This update includes current MEPs, including the latest adjustments ([this Wikipedia page](https://en.wikipedia.org/wiki/List_of_members_of_the_European_Parliament,_2019%E2%80%932024) includes link that explain why some left, and some others joined).

Other fixes:
- consistent https in the twitter link
- remove all white space around handles and such
- use the correct name surname and spelling provided by the European Parliament on their official website (e.g. many Romanian names previously used the wrong character for ş)
- add new twitter handles, partly based on the twitter list created by the EP press service
- update capitalisation of handles to match current defaults for each of them